### PR TITLE
Set up CI, add format and test scripts.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+# This file tells tools we use rustfmt. We use the default settings.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+# Travis CI script borrows heavily from CraneStation/wasmtime project.
+os:
+    - linux
+    - osx
+language: rust
+rust:
+    - stable
+    - beta
+    - nightly
+matrix:
+    allow_failures:
+        # We try to be compatible with beta and nightly, but they occasionally
+        # fail, so we don't allow them to hold up people using stable.
+        - rust: beta
+        - rust: nightly
+    # Similarly, we don't need to hold up people using stable while we wait
+    # for the results which may fail.
+    fast_finish: true
+dist: xenial
+sudo: false
+branches:
+    only:
+        - master
+before_script:
+    # If an old version of rustfmt from cargo is already installed, uninstall
+    # it, since it can prevent the installation of the new version from rustup.
+    - cargo uninstall rustfmt || true
+    - cargo install --list
+    # If we're testing beta or nightly, we still need to install the stable
+    # toolchain so that we can run the stable version of rustfmt.
+    - rustup toolchain install stable
+    # Install the stable version of rustfmt.
+    - rustup component add --toolchain=stable rustfmt-preview
+    - rustup component list --toolchain=stable
+    - rustup show
+    - rustfmt +stable --version || echo fail
+    # Sometimes the component isn't actually ready after being installed, and
+    # rustup update makes it ready.
+    - rustup update
+    - rustfmt +stable --version
+script: ./test-all.sh
+cache:
+    cargo: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "wasi-common"
 version = "0.1.0"
-authors = ["Adam C. Foltzer <acfoltzer@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>"]
+authors = [
+    "Adam C. Foltzer <acfoltzer@fastly.com>",
+    "Frank Denis <github@pureftpd.org>",
+    "Jakub Konka <kubkon@jakubkonka.com>",
+    "Dan Gohman <sunfish@mozilla.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
 cast = "0.2"
-clap = "2.23"
 failure = "0.1"
-human-size = "0.4"
 libc = "0.2"
 nix = "0.13"
 rand = "0.6"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = [ "WebAssembly" ]

--- a/format-all.sh
+++ b/format-all.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+# Format all sources using rustfmt.
+# This script borrows heavily from CraneStation/wasmtime project.
+
+topdir=$(dirname "$0")
+cd "$topdir"
+
+# Make sure we can find rustfmt.
+export PATH="$PATH:$HOME/.cargo/bin"
+
+exec cargo +stable fmt --all -- "$@"

--- a/src/host.rs
+++ b/src/host.rs
@@ -678,10 +678,17 @@ pub fn nix_from_filetype(sflags: __wasi_filetype_t) -> nix::sys::stat::SFlag {
 }
 
 pub fn filestat_from_nix(filestat: nix::sys::stat::FileStat) -> __wasi_filestat_t {
+    use std::convert::TryFrom;
+
     let filetype = nix::sys::stat::SFlag::from_bits_truncate(filestat.st_mode);
+    let dev = __wasi_device_t::try_from(filestat.st_dev)
+        .expect("FileStat::st_dev is trivially convertible to __wasi_device_t");
+    let ino = __wasi_inode_t::try_from(filestat.st_ino)
+        .expect("FileStat::st_ino is trivially convertible to __wasi_inode_t");
+
     __wasi_filestat_t {
-        st_dev: filestat.st_dev as __wasi_device_t,
-        st_ino: filestat.st_ino as __wasi_inode_t,
+        st_dev: dev,
+        st_ino: ino,
         st_nlink: filestat.st_nlink as __wasi_linkcount_t,
         st_size: filestat.st_size as __wasi_filesize_t,
         st_atim: filestat.st_atime as __wasi_timestamp_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,25 @@
+#![deny(
+    // missing_docs,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unstable_features
+)]
+#![warn(unused_import_braces)]
+#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../clippy.toml")))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    warn(
+        clippy::float_arithmetic,
+        clippy::mut_mut,
+        clippy::nonminimal_bool,
+        clippy::option_map_unwrap_or,
+        clippy::option_map_unwrap_or_else,
+        clippy::unicode_not_nfc,
+        clippy::use_self
+    )
+)]
+
 pub mod ctx;
 pub mod fdentry;
 pub mod host;

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# This is the top-level test script borrows heavily from CraneStation/wasmtime project:
+#
+# - Check code formatting.
+# - Make a debug build.
+# - Make a release build.
+# - Run unit tests for all Rust crates (including the filetests)
+# - Build API documentation.
+# - Optionally, run fuzzing.
+#
+# All tests run by this script should be passing at all times.
+
+# Repository top-level directory.
+topdir=$(dirname "$0")
+cd "$topdir"
+
+function banner {
+    echo "======  $*  ======"
+}
+
+# Run rustfmt if we have it.
+banner "Rust formatting"
+if cargo +stable fmt -- --version > /dev/null ; then
+    if ! "$topdir/format-all.sh" --check ; then
+        echo "Formatting diffs detected! Run \"cargo fmt --all\" to correct."
+        exit 1
+    fi
+else
+    echo "cargo-fmt not available; formatting not checked!"
+    echo
+    echo "If you are using rustup, rustfmt can be installed via"
+    echo "\"rustup component add --toolchain=stable rustfmt-preview\", or see"
+    echo "https://github.com/rust-lang-nursery/rustfmt for more information."
+fi
+
+# Make sure the code builds in release mode.
+banner "Rust release build"
+cargo build --release
+
+# Make sure the code builds in debug mode.
+banner "Rust debug build"
+cargo build
+
+# Run the tests. We run these in debug mode so that assertions are enabled.
+banner "Rust unit tests"
+RUST_BACKTRACE=1 cargo test
+
+# Make sure the documentation builds.
+banner "Rust documentation: $topdir/target/doc/wasi-common/index.html"
+cargo doc
+
+banner "OK"


### PR DESCRIPTION
Sets up CI, and adds format and test scripts. CI's setup and the scripts borrowed from [CraneStation/wasmtime](https://github.com/CraneStation/wasmtime) project. Also removes unused Cargo dependencies and fixes a trivial numeric cast.