### PR TITLE
Move TODO about proc_exit from wasmtime

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -26,6 +26,8 @@ use std::time::SystemTime;
 use std::{cmp, slice};
 
 pub fn proc_exit(rval: wasm32::__wasi_exitcode_t) -> () {
+    // TODO: Rather than call std::process::exit here, we should trigger a
+    // stack unwind similar to a trap.
     std::process::exit(dec_exitcode(rval) as i32);
 }
 


### PR DESCRIPTION
As requested in CraneStation/wasmtime#138.