### PR TITLE
Re-enable cargo cache in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ before_script:
     - rustfmt +stable --version
 script: ./test-all.sh
 cache:
-    cargo: false
+    cargo: true


### PR DESCRIPTION
Reverts 5ff4f57f9 which was added to properly update cargo deps in Travis CI when merging #15. Otherwise, the build would fail at `wasi-common-cbindgen-tests` with a linking error.