### PR TITLE
Backport path_get fix discovered in Win branch

### DIFF
--- a/src/sys/unix/hostcalls/fs_helpers.rs
+++ b/src/sys/unix/hostcalls/fs_helpers.rs
@@ -149,7 +149,7 @@ pub fn path_get<P: AsRef<OsStr>>(
                     || (component.ends_with(b"/") && !needs_final_component) =>
             {
                 match openat(
-                    *dir_stack.first().expect("dir_stack is never empty"),
+                    *dir_stack.last().expect("dir_stack is never empty"),
                     component,
                     OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW,
                     Mode::empty(),


### PR DESCRIPTION
Otherwise, for nested directories, we were trying an `openat` wrt the preopened fd always (regardless how far we've advanced down the path) rather than from the most recently opened fd. As a result, for a nested dir path like:

```
{preopened_fd}/a/b/c
```

it would result in a `ENOENT` error when processing `b/c`, since we'd try to open `b` also wrt `{preopened_fd}`:

```
{preopened_fd}/b/c
```

rather than wrt to freshly opened `a`:

```
a/b/c
```