### PR TITLE
Use `try_from` instead of the `cast` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
 wasi-common-cbindgen = { path = "wasi-common-cbindgen" }
-cast = "0.2"
 failure = "0.1"
 libc = "0.2"
 rand = "0.6"

--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -2,9 +2,7 @@
 use crate::ctx::WasiCtx;
 use crate::memory::*;
 use crate::wasm32;
-
-// NOTE avoid shadowing `std::convert::From` - cf. rust-lang/rfcs#1311
-use cast::From as _0;
+use std::convert::TryFrom;
 
 use wasi_common_cbindgen::wasi_common_cbindgen;
 
@@ -31,7 +29,7 @@ pub fn args_get(
         argv.push(arg_ptr);
 
         argv_buf_offset = if let Some(new_offset) = argv_buf_offset.checked_add(
-            wasm32::uintptr_t::cast(arg_bytes.len())
+            wasm32::uintptr_t::try_from(arg_bytes.len())
                 .expect("cast overflow would have been caught by `enc_slice_of` above"),
         ) {
             new_offset
@@ -89,7 +87,7 @@ pub fn environ_get(
         environ.push(env_ptr);
 
         environ_buf_offset = if let Some(new_offset) = environ_buf_offset.checked_add(
-            wasm32::uintptr_t::cast(env_bytes.len())
+            wasm32::uintptr_t::try_from(env_bytes.len())
                 .expect("cast overflow would have been caught by `enc_slice_of` above"),
         ) {
             new_offset

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,11 +1,7 @@
 //! Functions to go back and forth between WASI types in host and wasm32 representations.
 #![allow(unused)]
 use crate::{host, wasm32};
-
-// NOTE avoid shadowing `std::convert::From` - cf. rust-lang/rfcs#1311
-use cast::From as _0;
-
-use cast;
+use std::convert::TryFrom;
 use std::mem::{align_of, size_of};
 use std::ptr;
 use std::slice;
@@ -457,11 +453,11 @@ pub fn enc_u32(x: u32) -> u32 {
 }
 
 pub fn dec_usize(size: wasm32::size_t) -> usize {
-    cast::usize(u32::from_le(size))
+    usize::try_from(u32::from_le(size)).unwrap()
 }
 
 pub fn enc_usize(size: usize) -> wasm32::size_t {
-    wasm32::size_t::cast(size).unwrap()
+    wasm32::size_t::try_from(size).unwrap()
 }
 
 pub fn enc_usize_byref(


### PR DESCRIPTION
`try_from` is newly stable in the standard library starting in Rust 1.34.