### PR TITLE
Nix fixes

### DIFF
--- a/src/hostcalls/fs.rs
+++ b/src/hostcalls/fs.rs
@@ -580,16 +580,20 @@ pub fn path_readlink(
         Ok(slice) => host_impl::path_from_raw(slice).to_owned(),
         Err(e) => return enc_errno(e),
     };
-    let rights = host::__WASI_RIGHT_PATH_READLINK;
     let mut buf = match dec_slice_of_mut::<u8>(memory, buf_ptr, buf_len) {
         Ok(slice) => slice,
         Err(e) => return enc_errno(e),
     };
-    let host_bufused =
-        match hostcalls_impl::path_readlink(wasi_ctx, dirfd, path.as_os_str(), rights, &mut buf) {
-            Ok(host_bufused) => host_bufused,
-            Err(e) => return enc_errno(e),
-        };
+    let host_bufused = match hostcalls_impl::path_readlink(
+        wasi_ctx,
+        dirfd,
+        path.as_os_str(),
+        host::__WASI_RIGHT_PATH_READLINK,
+        &mut buf,
+    ) {
+        Ok(host_bufused) => host_bufused,
+        Err(e) => return enc_errno(e),
+    };
     match enc_usize_byref(memory, buf_used, host_bufused) {
         Ok(_) => wasm32::__WASI_ESUCCESS,
         Err(e) => enc_errno(e),

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -337,10 +337,10 @@ pub(crate) fn path_open(
 
     let mut nix_all_oflags = if read && write {
         OFlag::O_RDWR
-    } else if read {
-        OFlag::O_RDONLY
-    } else {
+    } else if write {
         OFlag::O_WRONLY
+    } else {
+        OFlag::O_RDONLY
     };
 
     // on non-Capsicum systems, we always want nofollow


### PR DESCRIPTION
This PR builds upon #26. It patches up all problems that cause [sunfishcode/misc-tests](https://github.com/sunfishcode/misc-tests) to fail.

Summary of fixes:
* `fd_renumber` should currently fail when trying to renumber a preopen
* `path_readlink` should be able to handle 0-sized buffer (as pointed out by @sunfishcode [in the original C impl](https://github.com/CraneStation/wasmtime/blob/master/wasmtime-wasi-c/sandboxed-system-primitives/src/posix.c#L1955), Linux requires the input buffer to have positive size, however, POSIX does not enforce that)
* `path_open` had the `OFlag`s the other way around: the `else` branch when determining read/write attributes should have `OFlags::O_RDONLY` as a fallthrough and not `OFlags::O_WRONLY` as it was until now
* `path_get` now correctly handles "interesting paths" with a plethora of trailing slashes, "..", etc. To achieve this, instead of iterating over raw paths (using bytes), we use `std::path::Components` functionality instead; it is still necessary to preserver the path's trailing slash so that opening a file as a dir fails as expected
* `path_get` now correctly fails with `EILSEQ` in the presence of spurious NULs in the input path
* applies fix CraneStation/wasmtime#173 to `path_open`
* fixes a typo in `path_open` to do with setting the `needed_base` flags in the presence of `OFlag::O_TRUNC`: up to now we were incorrectly adjusting `needed_inheriting` flags instead of `needed_base`
* finally, `path_unlink_file` now correctly handles non-Linux *nix OSes, i.e., `unlinkat` may return `EPERM` on non-Linux host and it should be adjusted to `EISDIR`