### PR TITLE
Fix inheriting stdio on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ cranelift-entity = "0.30.0"
 cranelift-wasm = "0.30.0"
 cranelift-native = "0.30.0"
 target-lexicon = "0.3.0"
+pretty_env_logger = "0.3.0"
 
 [patch."https://github.com/CraneStation/wasi-common"]
 wasi-common = { path = "." }

--- a/build.rs
+++ b/build.rs
@@ -55,7 +55,7 @@ fn test_directory(out: &mut File, testsuite: &str) -> io::Result<()> {
             .expect("testsuite filename should be representable as a string")
             .replace("-", "_")
     )?;
-    writeln!(out, "    use super::{{runtime, utils}};")?;
+    writeln!(out, "    use super::{{runtime, utils, setup_log}};")?;
     for dir_entry in dir_entries {
         write_testsuite_tests(out, dir_entry, testsuite)?;
     }
@@ -80,6 +80,7 @@ fn write_testsuite_tests(out: &mut File, dir_entry: DirEntry, testsuite: &str) -
         "    fn {}() -> Result<(), String> {{",
         avoid_keywords(&stemstr.replace("-", "_"))
     )?;
+    write!(out, "        setup_log();")?;
     write!(out, "        let path = std::path::Path::new(\"")?;
     // Write out the string with escape_debug to prevent special characters such
     // as backslash from being reinterpreted.

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -7,7 +7,6 @@ use failure::{bail, format_err, Error};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fs::File;
-use std::io::{stderr, stdin, stdout};
 use std::path::{Path, PathBuf};
 
 pub struct WasiCtxBuilder {
@@ -62,9 +61,9 @@ impl WasiCtxBuilder {
     }
 
     pub fn inherit_stdio(mut self) -> Self {
-        self.fds.insert(0, FdEntry::duplicate(&stdin()));
-        self.fds.insert(1, FdEntry::duplicate(&stdout()));
-        self.fds.insert(2, FdEntry::duplicate(&stderr()));
+        self.fds.insert(0, FdEntry::duplicate_stdin());
+        self.fds.insert(1, FdEntry::duplicate_stdout());
+        self.fds.insert(2, FdEntry::duplicate_stderr());
         self
     }
 

--- a/src/sys/unix/fdentry.rs
+++ b/src/sys/unix/fdentry.rs
@@ -1,6 +1,7 @@
 use crate::host;
 
 use std::fs::File;
+use std::io;
 use std::os::unix::prelude::{AsRawFd, FileTypeExt, FromRawFd, IntoRawFd, RawFd};
 use std::path::PathBuf;
 
@@ -34,7 +35,23 @@ impl FdEntry {
     }
 
     pub fn duplicate<F: AsRawFd>(fd: &F) -> Self {
-        unsafe { Self::from_raw_fd(nix::unistd::dup(fd.as_raw_fd()).unwrap()) }
+        unsafe { Self::duplicate_raw(fd.as_raw_fd()) }
+    }
+
+    pub unsafe fn duplicate_raw(fd: RawFd) -> Self {
+        Self::from_raw_fd(nix::unistd::dup(fd).unwrap())
+    }
+
+    pub fn duplicate_stdin() -> Self {
+        Self::duplicate(&io::stdin())
+    }
+
+    pub fn duplicate_stdout() -> Self {
+        Self::duplicate(&io::stdout())
+    }
+
+    pub fn duplicate_stderr() -> Self {
+        Self::duplicate(&io::stderr())
     }
 }
 

--- a/src/sys/windows/fdentry.rs
+++ b/src/sys/windows/fdentry.rs
@@ -1,7 +1,8 @@
 use super::host_impl;
 use crate::host;
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
+use std::io;
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 use std::path::PathBuf;
 
@@ -37,6 +38,64 @@ impl FdEntry {
 
     pub fn duplicate<F: AsRawHandle>(fd: &F) -> Self {
         unsafe { Self::from_raw_handle(winx::handle::dup(fd.as_raw_handle()).unwrap()) }
+    }
+
+    pub fn duplicate_stdin() -> Self {
+        let handle = io::stdin().as_raw_handle();
+        let file_type = winx::file::get_file_type(handle).expect("could get handle's file type");
+        // [MSDN 2018] the SetStdHandle function can redirect the standard
+        // handles by changing the handle associated with STDIN, STDOUT, or STDERR.
+        // Because the parent's standard handles are inherited by any child process,
+        // subsequent calls to GetStdHandle return the *redirected* handle.
+        // ...
+        // The CreateFile function enables a process to get a handle to its console's
+        // input buffer and active screen buffer, even if STDIN and STDOUT have been redirected.
+        // To open a handle to a console's input buffer, specify the CONIN$ value in a call
+        // to CreateFile. Specify the CONOUT$ value in a call to CreateFile to open a handle
+        // to a console's active screen buffer.
+        //
+        // [MSDN 2018]: https://docs.microsoft.com/en-us/windows/console/console-handles
+        if file_type.is_pipe() {
+            let stdin = OpenOptions::new()
+                .write(false)
+                .read(true)
+                .open("CONIN$")
+                .expect("could open STDIN");
+            Self::duplicate(&stdin)
+        // stdin will get closed automatically when we leave the scope
+        } else {
+            Self::duplicate(&io::stdin())
+        }
+    }
+
+    pub fn duplicate_stdout() -> Self {
+        let handle = io::stdout().as_raw_handle();
+        let file_type = winx::file::get_file_type(handle).expect("could get handle's file type");
+        if file_type.is_pipe() {
+            let stdout = OpenOptions::new()
+                .write(true)
+                .read(false)
+                .open("CONOUT$")
+                .expect("could open STDOUT");
+            Self::duplicate(&stdout)
+        } else {
+            Self::duplicate(&io::stdout())
+        }
+    }
+
+    pub fn duplicate_stderr() -> Self {
+        let handle = io::stderr().as_raw_handle();
+        let file_type = winx::file::get_file_type(handle).expect("could get handle's file type");
+        if file_type.is_pipe() {
+            let stderr = OpenOptions::new()
+                .write(true)
+                .read(false)
+                .open("CONOUT$")
+                .expect("could open STDOUT as STDERR");
+            Self::duplicate(&stderr)
+        } else {
+            Self::duplicate(&io::stderr())
+        }
     }
 }
 

--- a/tests/misc_tests.rs
+++ b/tests/misc_tests.rs
@@ -1,4 +1,14 @@
 mod runtime;
 mod utils;
 
+use std::sync::{Once, ONCE_INIT};
+
+static LOG_INIT: Once = ONCE_INIT;
+
+fn setup_log() {
+    LOG_INIT.call_once(|| {
+        pretty_env_logger::init();
+    })
+}
+
 include!(concat!(env!("OUT_DIR"), "/misc_testsuite_tests.rs"));


### PR DESCRIPTION
This PR fixes failures on CIs with the recent changes to Windows implementation (you can see an example of such a failure [here](https://travis-ci.org/CraneStation/wasi-common/jobs/551644215)). As it turns out, the CI in Windows builds pipes the `stdio` handles raising an `ERROR_INVALID_HANDLE` error when trying to duplicate them on Windows.

The proposed fix to this problem is to create a handle to `stdio` manually (using `CreateFile` winapi call rather than relying on `GetStdHandle` as it's customary; in Rust terms, we'd use `OpenOptions` to create a new handle to `STDIN` and `STDOUT` rather than relying on `Stdin` and `Stdout` structs). This is in accordance with the official [MSDN docs](https://docs.microsoft.com/en-us/windows/console/console-handles):

> the SetStdHandle function can redirect the standard handles by changing the handle associated with STDIN, STDOUT, or STDERR. Because the parent's standard handles are inherited by any child process, subsequent calls to GetStdHandle return the *redirected* handle.

> The CreateFile function enables a process to get a handle to its console's input buffer and active screen buffer, even if STDIN and STDOUT have been redirected. To open a handle to a console's input buffer, specify the CONIN$ value in a call to CreateFile. Specify the CONOUT$ value in a call to CreateFile to open a handle to a console's active screen buffer.

However, I welcome some discussion and suggestions here on what the best approach to this problem would be.