### PR TITLE
WASI paths as &str and String

### DIFF
--- a/src/hostcalls/fs.rs
+++ b/src/hostcalls/fs.rs
@@ -2,10 +2,11 @@
 use super::return_enc_errno;
 use crate::ctx::WasiCtx;
 use crate::fdentry::Descriptor;
+use crate::host::{self, RawString};
 use crate::memory::*;
-use crate::sys::host_impl::RawString;
+use crate::sys::host_impl::RawStringExt;
 use crate::sys::{errno_from_host, hostcalls_impl};
-use crate::{host, wasm32};
+use crate::wasm32;
 use log::trace;
 use std::convert::identity;
 use std::io::{self, Read, Write};
@@ -593,8 +594,9 @@ pub fn path_create_directory(
     );
 
     let dirfd = dec_fd(dirfd);
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -633,12 +635,16 @@ pub fn path_link(
 
     let old_dirfd = dec_fd(old_dirfd);
     let new_dirfd = dec_fd(new_dirfd);
-    let old_path = match dec_slice_of::<u8>(memory, old_path_ptr, old_path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let old_path = match dec_slice_of::<u8>(memory, old_path_ptr, old_path_len)
+        .and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
-    let new_path = match dec_slice_of::<u8>(memory, new_path_ptr, new_path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let new_path = match dec_slice_of::<u8>(memory, new_path_ptr, new_path_len)
+        .and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -708,8 +714,9 @@ pub fn path_open(
     let needed_base = host::__WASI_RIGHT_PATH_OPEN;
     let needed_inheriting = fs_rights_base | fs_rights_inheriting;
 
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -829,8 +836,9 @@ pub fn path_readlink(
         Err(e) => return return_enc_errno(e),
     };
     let dirfd = dec_fd(dirfd);
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -884,12 +892,16 @@ pub fn path_rename(
 
     let old_dirfd = dec_fd(old_dirfd);
     let new_dirfd = dec_fd(new_dirfd);
-    let old_path = match dec_slice_of::<u8>(memory, old_path_ptr, old_path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let old_path = match dec_slice_of::<u8>(memory, old_path_ptr, old_path_len)
+        .and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
-    let new_path = match dec_slice_of::<u8>(memory, new_path_ptr, new_path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let new_path = match dec_slice_of::<u8>(memory, new_path_ptr, new_path_len)
+        .and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -1025,8 +1037,9 @@ pub fn path_filestat_get(
 
     let dirfd = dec_fd(dirfd);
     let dirflags = dec_lookupflags(dirflags);
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -1071,8 +1084,9 @@ pub fn path_filestat_set_times(
 
     let dirfd = dec_fd(dirfd);
     let dirflags = dec_lookupflags(dirflags);
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -1113,12 +1127,16 @@ pub fn path_symlink(
     );
 
     let dirfd = dec_fd(dirfd);
-    let old_path = match dec_slice_of::<u8>(memory, old_path_ptr, old_path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let old_path = match dec_slice_of::<u8>(memory, old_path_ptr, old_path_len)
+        .and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
-    let new_path = match dec_slice_of::<u8>(memory, new_path_ptr, new_path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let new_path = match dec_slice_of::<u8>(memory, new_path_ptr, new_path_len)
+        .and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -1151,8 +1169,9 @@ pub fn path_unlink_file(
     );
 
     let dirfd = dec_fd(dirfd);
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -1187,8 +1206,9 @@ pub fn path_remove_directory(
     );
 
     let dirfd = dec_fd(dirfd);
-    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len) {
-        Ok(slice) => RawString::from_bytes(slice),
+    let path = match dec_slice_of::<u8>(memory, path_ptr, path_len).and_then(RawString::from_bytes)
+    {
+        Ok(path) => path,
         Err(e) => return return_enc_errno(e),
     };
 
@@ -1225,6 +1245,12 @@ pub fn fd_prestat_get(
                 if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
                     return return_enc_errno(host::__WASI_ENOTDIR);
                 }
+
+                let raw_bytes = match RawString::from(po_path.as_ref()).to_bytes() {
+                    Ok(raw_bytes) => raw_bytes,
+                    Err(e) => return return_enc_errno(e),
+                };
+
                 enc_prestat_byref(
                     memory,
                     prestat_ptr,
@@ -1232,7 +1258,7 @@ pub fn fd_prestat_get(
                         pr_type: host::__WASI_PREOPENTYPE_DIR,
                         u: host::__wasi_prestat_t___wasi_prestat_u {
                             dir: host::__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
-                                pr_name_len: RawString::from(po_path.as_ref()).to_bytes().len(),
+                                pr_name_len: raw_bytes.len(),
                             },
                         },
                     },
@@ -1272,14 +1298,19 @@ pub fn fd_prestat_dir_name(
                 if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
                     return return_enc_errno(host::__WASI_ENOTDIR);
                 }
-                let path_bytes = RawString::from(po_path.as_ref()).to_bytes();
-                if path_bytes.len() > dec_usize(path_len) {
+
+                let raw_bytes = match RawString::from(po_path.as_ref()).to_bytes() {
+                    Ok(raw_bytes) => raw_bytes,
+                    Err(e) => return return_enc_errno(e),
+                };
+
+                if raw_bytes.len() > dec_usize(path_len) {
                     return return_enc_errno(host::__WASI_ENAMETOOLONG);
                 }
 
                 trace!("     | (path_ptr,path_len)={:?}", po_path);
 
-                enc_slice_of(memory, &path_bytes, path_ptr)
+                enc_slice_of(memory, &raw_bytes, path_ptr)
                     .map(|_| host::__WASI_ESUCCESS)
                     .unwrap_or_else(identity)
             } else {

--- a/src/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -3,9 +3,9 @@
 
 use crate::ctx::WasiCtx;
 use crate::fdentry::Descriptor;
-use crate::host;
+use crate::host::{self, RawString};
 use crate::sys::errno_from_host;
-use crate::sys::host_impl::{self, RawString};
+use crate::sys::host_impl::{self, RawStringExt};
 
 use nix::libc::{self, c_long};
 use std::ffi::OsStr;
@@ -26,7 +26,7 @@ pub fn path_get(
 ) -> Result<(File, RawString), host::__wasi_errno_t> {
     const MAX_SYMLINK_EXPANSIONS: usize = 128;
 
-    if path.contains(&b'\0') {
+    if path.contains(&b'\0')? {
         // if contains NUL, return EILSEQ
         return Err(host::__WASI_EILSEQ);
     }
@@ -60,7 +60,7 @@ pub fn path_get(
             Some(cur_path) => {
                 // eprintln!("cur_path = {:?}", cur_path);
 
-                let ends_with_slash = cur_path.ends_with(b"/");
+                let ends_with_slash = cur_path.ends_with(b"/")?;
                 let mut components = Path::new(&cur_path).components();
                 let head = match components.next() {
                     None => return Err(host::__WASI_ENOENT),
@@ -125,7 +125,7 @@ pub fn path_get(
                                                 return Err(host::__WASI_ELOOP);
                                             }
 
-                                            if head.ends_with(b"/") {
+                                            if head.ends_with(b"/")? {
                                                 link_path.push("/");
                                             }
 
@@ -156,7 +156,7 @@ pub fn path_get(
                                         return Err(host::__WASI_ELOOP);
                                     }
 
-                                    if head.ends_with(b"/") {
+                                    if head.ends_with(b"/")? {
                                         link_path.push("/");
                                     }
 

--- a/src/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -3,30 +3,28 @@
 
 use crate::ctx::WasiCtx;
 use crate::fdentry::Descriptor;
-use crate::host::{self, RawString};
+use crate::host;
 use crate::sys::errno_from_host;
-use crate::sys::host_impl::{self, RawStringExt};
-
+use crate::sys::host_impl;
 use nix::libc::{self, c_long};
-use std::ffi::OsStr;
 use std::fs::File;
 use std::path::{Component, Path};
 
 /// Normalizes a path to ensure that the target path is located under the directory provided.
 ///
 /// This is a workaround for not having Capsicum support in the OS.
-pub fn path_get(
+pub(crate) fn path_get(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
     dirflags: host::__wasi_lookupflags_t,
-    path: &RawString,
+    path: &str,
     needed_base: host::__wasi_rights_t,
     needed_inheriting: host::__wasi_rights_t,
     needs_final_component: bool,
-) -> Result<(File, RawString), host::__wasi_errno_t> {
+) -> Result<(File, String), host::__wasi_errno_t> {
     const MAX_SYMLINK_EXPANSIONS: usize = 128;
 
-    if path.contains(&b'\0')? {
+    if path.contains("\0") {
         // if contains NUL, return EILSEQ
         return Err(host::__WASI_EILSEQ);
     }
@@ -48,7 +46,7 @@ pub fn path_get(
 
     // Stack of paths left to process. This is initially the `path` argument to this function, but
     // any symlinks we encounter are processed by pushing them on the stack.
-    let mut path_stack = vec![path.clone()];
+    let mut path_stack = vec![path.to_owned()];
 
     // Track the number of symlinks we've expanded, so we can return `ELOOP` after too many.
     let mut symlink_expansions = 0;
@@ -60,7 +58,7 @@ pub fn path_get(
             Some(cur_path) => {
                 // eprintln!("cur_path = {:?}", cur_path);
 
-                let ends_with_slash = cur_path.ends_with(b"/")?;
+                let ends_with_slash = cur_path.ends_with("/");
                 let mut components = Path::new(&cur_path).components();
                 let head = match components.next() {
                     None => return Err(host::__WASI_ENOENT),
@@ -69,9 +67,9 @@ pub fn path_get(
                 let tail = components.as_path();
 
                 if tail.components().next().is_some() {
-                    let mut tail = RawString::from(tail.as_os_str());
+                    let mut tail = host_impl::path_from_host(tail.as_os_str())?;
                     if ends_with_slash {
-                        tail.push("/");
+                        tail.push_str("/");
                     }
                     path_stack.push(tail);
                 }
@@ -95,10 +93,10 @@ pub fn path_get(
                         }
                     }
                     Component::Normal(head) => {
-                        let mut head = RawString::from(head);
+                        let mut head = host_impl::path_from_host(head)?;
                         if ends_with_slash {
                             // preserve trailing slash
-                            head.push("/");
+                            head.push_str("/");
                         }
 
                         if !path_stack.is_empty() || (ends_with_slash && !needs_final_component) {
@@ -125,8 +123,8 @@ pub fn path_get(
                                                 return Err(host::__WASI_ELOOP);
                                             }
 
-                                            if head.ends_with(b"/")? {
-                                                link_path.push("/");
+                                            if head.ends_with("/") {
+                                                link_path.push_str("/");
                                             }
 
                                             path_stack.push(link_path);
@@ -156,8 +154,8 @@ pub fn path_get(
                                         return Err(host::__WASI_ELOOP);
                                     }
 
-                                    if head.ends_with(b"/")? {
-                                        link_path.push("/");
+                                    if head.ends_with("/") {
+                                        link_path.push_str("/");
                                     }
 
                                     path_stack.push(link_path);
@@ -181,21 +179,21 @@ pub fn path_get(
                 // input path has trailing slashes and `needs_final_component` is not set
                 return Ok((
                     dir_stack.pop().ok_or(host::__WASI_ENOTCAPABLE)?,
-                    RawString::from(OsStr::new(".")),
+                    String::from("."),
                 ));
             }
         }
     }
 }
 
-fn openat(dirfd: &File, path: &RawString) -> Result<File, host::__wasi_errno_t> {
+fn openat(dirfd: &File, path: &str) -> Result<File, host::__wasi_errno_t> {
     use nix::fcntl::{self, OFlag};
     use nix::sys::stat::Mode;
     use std::os::unix::prelude::{AsRawFd, FromRawFd};
 
     fcntl::openat(
         dirfd.as_raw_fd(),
-        path.as_ref(),
+        path,
         OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW,
         Mode::empty(),
     )
@@ -203,15 +201,15 @@ fn openat(dirfd: &File, path: &RawString) -> Result<File, host::__wasi_errno_t> 
     .map_err(|e| host_impl::errno_from_nix(e.as_errno().unwrap()))
 }
 
-fn readlinkat(dirfd: &File, path: &RawString) -> Result<RawString, host::__wasi_errno_t> {
+fn readlinkat(dirfd: &File, path: &str) -> Result<String, host::__wasi_errno_t> {
     use nix::fcntl;
     use std::os::unix::prelude::AsRawFd;
 
     let readlink_buf = &mut [0u8; libc::PATH_MAX as usize + 1];
 
-    fcntl::readlinkat(dirfd.as_raw_fd(), path.as_ref(), readlink_buf)
-        .map(RawString::from)
+    fcntl::readlinkat(dirfd.as_raw_fd(), path, readlink_buf)
         .map_err(|e| host_impl::errno_from_nix(e.as_errno().unwrap()))
+        .and_then(host_impl::path_from_host)
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/src/sys/windows/host_impl.rs
+++ b/src/sys/windows/host_impl.rs
@@ -2,12 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(unused)]
-use crate::host::{self, AsInner, FromInner, RawString};
-use std::ffi::{OsStr, OsString};
-use std::marker::PhantomData;
-use std::os::windows::prelude::{OsStrExt, OsStringExt};
-use std::slice;
-use std::str;
+use crate::host;
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
 
 pub fn errno_from_win(error: winx::winerror::WinError) -> host::__wasi_errno_t {
     // TODO: implement error mapping between Windows and WASI
@@ -107,49 +104,11 @@ pub fn win_from_oflags(
     (win_disp, win_flags_attrs)
 }
 
-pub(crate) trait RawStringExt {
-    fn from_bytes(slice: &[u8]) -> Result<RawString, host::__wasi_errno_t>;
-    fn to_bytes(&self) -> Result<Vec<u8>, host::__wasi_errno_t>;
-    fn contains(&self, c: &u8) -> Result<bool, host::__wasi_errno_t>;
-    fn ends_with(&self, c: &[u8]) -> Result<bool, host::__wasi_errno_t>;
-}
-
-impl RawStringExt for RawString {
-    fn from_bytes(slice: &[u8]) -> Result<RawString, host::__wasi_errno_t> {
-        to_utf16(slice).map(|s| FromInner::from_inner(OsString::from_wide(&s)))
-    }
-
-    fn to_bytes(&self) -> Result<Vec<u8>, host::__wasi_errno_t> {
-        self.as_inner()
-            .to_str()
-            .map(|s| s.as_bytes().to_owned())
-            .ok_or(host::__WASI_EILSEQ)
-    }
-
-    fn contains(&self, c: &u8) -> Result<bool, host::__wasi_errno_t> {
-        let c = &[*c];
-        let mut u16s = to_utf16(c)?;
-        if u16s.len() > 1 {
-            return Err(host::__WASI_EILSEQ);
-        }
-        u16s.pop()
-            .map(|c| self.as_inner().encode_wide().find(|&x| x == c).is_some())
-            .ok_or(host::__WASI_EILSEQ)
-    }
-
-    fn ends_with(&self, cs: &[u8]) -> Result<bool, host::__wasi_errno_t> {
-        let cs = to_utf16(cs)?;
-        let ss: Vec<u16> = self.as_inner().encode_wide().collect();
-        Ok(ss
-            .into_iter()
-            .rev()
-            .zip(cs.into_iter().rev())
-            .all(|(l, r)| l == r))
-    }
-}
-
-fn to_utf16(slice: &[u8]) -> Result<Vec<u16>, host::__wasi_errno_t> {
-    str::from_utf8(slice)
-        .map(|s| s.encode_utf16().collect())
-        .map_err(|_| host::__WASI_EILSEQ)
+/// Creates owned WASI path from OS string.
+///
+/// NB WASI spec requires OS string to be valid UTF-8. Otherwise,
+/// `__WASI_EILSEQ` error is returned.
+pub fn path_from_host<S: AsRef<OsStr>>(s: S) -> Result<String, host::__wasi_errno_t> {
+    let vec: Vec<u16> = s.as_ref().encode_wide().collect();
+    String::from_utf16(&vec).map_err(|_| host::__WASI_EILSEQ)
 }

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -3,11 +3,10 @@
 use super::fs_helpers::*;
 use crate::ctx::WasiCtx;
 use crate::fdentry::FdEntry;
-use crate::host;
+use crate::host::{self, RawString};
 use crate::sys::errno_from_host;
 use crate::sys::fdentry_impl::determine_type_rights;
-use crate::sys::host_impl::{self, RawString};
-
+use crate::sys::host_impl::{self, RawStringExt};
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom};
 use std::os::windows::fs::FileExt;

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -3,10 +3,10 @@
 use super::fs_helpers::*;
 use crate::ctx::WasiCtx;
 use crate::fdentry::FdEntry;
-use crate::host::{self, RawString};
+use crate::host;
 use crate::sys::errno_from_host;
 use crate::sys::fdentry_impl::determine_type_rights;
-use crate::sys::host_impl::{self, RawStringExt};
+use crate::sys::host_impl;
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom};
 use std::os::windows::fs::FileExt;
@@ -101,7 +101,7 @@ pub(crate) fn fd_advise(
 pub(crate) fn path_create_directory(
     ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
-    path: &RawString,
+    path: &str,
 ) -> Result<(), host::__wasi_errno_t> {
     unimplemented!("path_create_directory")
 }
@@ -110,8 +110,8 @@ pub(crate) fn path_link(
     ctx: &WasiCtx,
     old_dirfd: host::__wasi_fd_t,
     new_dirfd: host::__wasi_fd_t,
-    old_path: &RawString,
-    new_path: &RawString,
+    old_path: &str,
+    new_path: &str,
     source_rights: host::__wasi_rights_t,
     target_rights: host::__wasi_rights_t,
 ) -> Result<(), host::__wasi_errno_t> {
@@ -122,7 +122,7 @@ pub(crate) fn path_open(
     ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
     dirflags: host::__wasi_lookupflags_t,
-    path: &RawString,
+    path: &str,
     oflags: host::__wasi_oflags_t,
     read: bool,
     write: bool,
@@ -174,7 +174,7 @@ pub(crate) fn path_open(
 
     let new_handle = match winx::file::openat(
         dir.as_raw_handle(),
-        &path,
+        path.as_str(),
         win_rights,
         win_create_disp,
         win_flags_attrs,
@@ -207,7 +207,7 @@ pub(crate) fn fd_readdir(
 pub(crate) fn path_readlink(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
-    path: &RawString,
+    path: &str,
     rights: host::__wasi_rights_t,
     buf: &mut [u8],
 ) -> Result<usize, host::__wasi_errno_t> {
@@ -217,10 +217,10 @@ pub(crate) fn path_readlink(
 pub(crate) fn path_rename(
     wasi_ctx: &WasiCtx,
     old_dirfd: host::__wasi_fd_t,
-    old_path: &RawString,
+    old_path: &str,
     old_rights: host::__wasi_rights_t,
     new_dirfd: host::__wasi_fd_t,
-    new_path: &RawString,
+    new_path: &str,
     new_rights: host::__wasi_rights_t,
 ) -> Result<(), host::__wasi_errno_t> {
     unimplemented!("path_rename")
@@ -252,7 +252,7 @@ pub(crate) fn path_filestat_get(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
     dirflags: host::__wasi_lookupflags_t,
-    path: &RawString,
+    path: &str,
 ) -> Result<host::__wasi_filestat_t, host::__wasi_errno_t> {
     unimplemented!("path_filestat_get")
 }
@@ -261,7 +261,7 @@ pub(crate) fn path_filestat_set_times(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
     dirflags: host::__wasi_lookupflags_t,
-    path: &RawString,
+    path: &str,
     rights: host::__wasi_rights_t,
     st_atim: host::__wasi_timestamp_t,
     mut st_mtim: host::__wasi_timestamp_t,
@@ -274,8 +274,8 @@ pub(crate) fn path_symlink(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
     rights: host::__wasi_rights_t,
-    old_path: &RawString,
-    new_path: &RawString,
+    old_path: &str,
+    new_path: &str,
 ) -> Result<(), host::__wasi_errno_t> {
     unimplemented!("path_symlink")
 }
@@ -283,7 +283,7 @@ pub(crate) fn path_symlink(
 pub(crate) fn path_unlink_file(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
-    path: &RawString,
+    path: &str,
     rights: host::__wasi_rights_t,
 ) -> Result<(), host::__wasi_errno_t> {
     unimplemented!("path_unlink_file")
@@ -292,7 +292,7 @@ pub(crate) fn path_unlink_file(
 pub(crate) fn path_remove_directory(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
-    path: &RawString,
+    path: &str,
     rights: host::__wasi_rights_t,
 ) -> Result<(), host::__wasi_errno_t> {
     unimplemented!("path_remove_directory")

--- a/src/sys/windows/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/windows/hostcalls_impl/fs_helpers.rs
@@ -3,10 +3,9 @@
 
 use crate::ctx::WasiCtx;
 use crate::fdentry::Descriptor;
-use crate::host;
+use crate::host::{self, RawString};
 use crate::sys::errno_from_host;
-use crate::sys::host_impl::{self, RawString};
-
+use crate::sys::host_impl::{self, RawStringExt};
 use std::ffi::OsStr;
 use std::fs::File;
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle};
@@ -22,7 +21,7 @@ pub fn path_get(
     needed_inheriting: host::__wasi_rights_t,
     needs_final_component: bool,
 ) -> Result<(File, RawString), host::__wasi_errno_t> {
-    if path.contains(&b'\0') {
+    if path.contains(&b'\0')? {
         // if contains NUL, return EILSEQ
         return Err(host::__WASI_EILSEQ);
     }
@@ -50,7 +49,7 @@ pub fn path_get(
         match path_stack.pop() {
             Some(cur_path) => {
                 // dbg!(&cur_path);
-                let ends_with_slash = cur_path.ends_with(b"/");
+                let ends_with_slash = cur_path.ends_with(b"/")?;
                 let mut components = Path::new(&cur_path).components();
                 let head = match components.next() {
                     None => return Err(host::__WASI_ENOENT),

--- a/src/sys/windows/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/windows/hostcalls_impl/fs_helpers.rs
@@ -3,25 +3,24 @@
 
 use crate::ctx::WasiCtx;
 use crate::fdentry::Descriptor;
-use crate::host::{self, RawString};
+use crate::host;
 use crate::sys::errno_from_host;
-use crate::sys::host_impl::{self, RawStringExt};
-use std::ffi::OsStr;
+use crate::sys::host_impl;
 use std::fs::File;
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle};
 use std::path::{Component, Path};
 
 /// Normalizes a path to ensure that the target path is located under the directory provided.
-pub fn path_get(
+pub(crate) fn path_get(
     wasi_ctx: &WasiCtx,
     dirfd: host::__wasi_fd_t,
     _dirflags: host::__wasi_lookupflags_t,
-    path: &RawString,
+    path: &str,
     needed_base: host::__wasi_rights_t,
     needed_inheriting: host::__wasi_rights_t,
     needs_final_component: bool,
-) -> Result<(File, RawString), host::__wasi_errno_t> {
-    if path.contains(&b'\0')? {
+) -> Result<(File, String), host::__wasi_errno_t> {
+    if path.contains("\0") {
         // if contains NUL, return EILSEQ
         return Err(host::__WASI_EILSEQ);
     }
@@ -43,13 +42,13 @@ pub fn path_get(
 
     // Stack of paths left to process. This is initially the `path` argument to this function, but
     // any symlinks we encounter are processed by pushing them on the stack.
-    let mut path_stack = vec![path.clone()];
+    let mut path_stack = vec![path.to_owned()];
 
     loop {
         match path_stack.pop() {
             Some(cur_path) => {
                 // dbg!(&cur_path);
-                let ends_with_slash = cur_path.ends_with(b"/")?;
+                let ends_with_slash = cur_path.ends_with("/");
                 let mut components = Path::new(&cur_path).components();
                 let head = match components.next() {
                     None => return Err(host::__WASI_ENOENT),
@@ -58,9 +57,9 @@ pub fn path_get(
                 let tail = components.as_path();
 
                 if tail.components().next().is_some() {
-                    let mut tail = RawString::from(tail.as_os_str());
+                    let mut tail = host_impl::path_from_host(tail.as_os_str())?;
                     if ends_with_slash {
-                        tail.push("/");
+                        tail.push_str("/");
                     }
                     path_stack.push(tail);
                 }
@@ -84,10 +83,10 @@ pub fn path_get(
                         }
                     }
                     Component::Normal(head) => {
-                        let mut head = RawString::from(head);
+                        let mut head = host_impl::path_from_host(head)?;
                         if ends_with_slash {
                             // preserve trailing slash
-                            head.push("/");
+                            head.push_str("/");
                         }
                         // should the component be a directory? it should if there is more path left to process, or
                         // if it has a trailing slash and `needs_final_component` is not set
@@ -97,7 +96,7 @@ pub fn path_get(
                                     .last()
                                     .ok_or(host::__WASI_ENOTCAPABLE)?
                                     .as_raw_handle(),
-                                head.as_ref(),
+                                head.as_str(),
                                 winx::file::AccessRight::FILE_GENERIC_READ,
                                 winx::file::CreationDisposition::OPEN_EXISTING,
                                 winx::file::FlagsAndAttributes::FILE_FLAG_BACKUP_SEMANTICS,
@@ -122,7 +121,7 @@ pub fn path_get(
                 // input path has trailing slashes and `needs_final_component` is not set
                 return Ok((
                     dir_stack.pop().ok_or(host::__WASI_ENOTCAPABLE)?,
-                    RawString::from(OsStr::new(".")),
+                    String::from("."),
                 ));
             }
         }


### PR DESCRIPTION
This PR address @sunfishcode concerns about proper/improper conversion from/to UTF-8 across different hosts raise in #34. As such, it verifies that input path (from Wasm) is a valid UTF-8, then performs a translation into correct encoding for the host (UTF-8 on *nix, UTF-16 on Windows), and performs any relevant calls involving the path.