### PR TITLE
Implement fd_filestat_get for all platforms

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,10 @@
+use crate::{host, Result};
+use std::convert::TryInto;
+use std::time::{SystemTime, UNIX_EPOCH};
+pub(crate) fn systemtime_to_timestamp(st: SystemTime) -> Result<u64> {
+    st.duration_since(UNIX_EPOCH)
+        .map_err(|_| host::__WASI_EINVAL)? // date earlier than UNIX_EPOCH
+        .as_nanos()
+        .try_into()
+        .map_err(|_| host::__WASI_EOVERFLOW) // u128 doesn't fit into u64
+}

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -4,7 +4,7 @@ use crate::fdentry::{Descriptor, FdEntry};
 use crate::memory::*;
 use crate::sys::{errno_from_host, host_impl, hostcalls_impl};
 use crate::{host, wasm32, Result};
-use log::trace;
+use log::{debug, trace};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 pub(crate) fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
@@ -730,11 +730,44 @@ pub(crate) fn fd_filestat_get(
         .get_fd_entry(fd, 0, 0)
         .and_then(|fe| fe.fd_object.descriptor.as_file())?;
 
-    let host_filestat = hostcalls_impl::fd_filestat_get(fd)?;
+    let host_filestat = fd_filestat_get_impl(fd).map_err(|e| {
+        debug!("fd_filestat_get: error: {}", e);
+        e.raw_os_error().map_or(host::__WASI_EIO, errno_from_host)
+    })?;
 
     trace!("     | *filestat_ptr={:?}", host_filestat);
 
     enc_filestat_byref(memory, filestat_ptr, host_filestat)
+}
+
+fn fd_filestat_get_impl(file: &std::fs::File) -> io::Result<host::__wasi_filestat_t> {
+    use std::convert::TryInto;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    fn timestamp(st: SystemTime) -> io::Result<u64> {
+        st.duration_since(UNIX_EPOCH)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
+            .as_nanos()
+            .try_into()
+            .map_err(|e: std::num::TryFromIntError| {
+                io::Error::new(io::ErrorKind::Other, e.to_string())
+            })
+    }
+    let metadata = file.metadata()?;
+    // On Windows all the information needed is either in libstd or provided by
+    // GetFileInformationByHandle winapi call. All of it is much easier to implement
+    // in libstd
+    Ok(host::__wasi_filestat_t {
+        st_dev: hostcalls_impl::device_id(file)?,
+        st_ino: hostcalls_impl::file_serial_no(file)?,
+        st_nlink: hostcalls_impl::num_hardlinks(file)?
+            .try_into()
+            .expect("overflow"),
+        st_size: metadata.len(),
+        st_atim: metadata.accessed().and_then(timestamp)?,
+        st_ctim: hostcalls_impl::change_time(file)?,
+        st_mtim: metadata.modified().and_then(timestamp)?,
+        st_filetype: hostcalls_impl::filetype(file)?,
+    })
 }
 
 pub(crate) fn fd_filestat_set_times(

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -753,9 +753,6 @@ fn fd_filestat_get_impl(file: &std::fs::File) -> io::Result<host::__wasi_filesta
             })
     }
     let metadata = file.metadata()?;
-    // On Windows all the information needed is either in libstd or provided by
-    // GetFileInformationByHandle winapi call. All of it is much easier to implement
-    // in libstd
     Ok(host::__wasi_filestat_t {
         st_dev: hostcalls_impl::device_id(file)?,
         st_ino: hostcalls_impl::file_serial_no(file)?,

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -761,7 +761,7 @@ fn fd_filestat_get_impl(file: &std::fs::File) -> io::Result<host::__wasi_filesta
             .expect("overflow"),
         st_size: metadata.len(),
         st_atim: metadata.accessed().and_then(timestamp)?,
-        st_ctim: hostcalls_impl::change_time(file)?,
+        st_ctim: hostcalls_impl::change_time(file)?.try_into().expect("overflow"),
         st_mtim: metadata.modified().and_then(timestamp)?,
         st_filetype: hostcalls_impl::filetype(file)?,
     })

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -756,9 +756,9 @@ fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_filestat_t>
 
     let metadata = file.metadata().map_err(convert_err)?;
     Ok(host::__wasi_filestat_t {
-        st_dev: hostcalls_impl::device_id(file).map_err(convert_err)?,
-        st_ino: hostcalls_impl::file_serial_no(file).map_err(convert_err)?,
-        st_nlink: hostcalls_impl::num_hardlinks(file)
+        st_dev: hostcalls_impl::device_id(file, &metadata).map_err(convert_err)?,
+        st_ino: hostcalls_impl::file_serial_no(file, &metadata).map_err(convert_err)?,
+        st_nlink: hostcalls_impl::num_hardlinks(file, &metadata)
             .map_err(convert_err)?
             .try_into()
             .map_err(|_| host::__WASI_EOVERFLOW)?, // u64 doesn't fit into u32
@@ -767,7 +767,7 @@ fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_filestat_t>
             .accessed()
             .map_err(convert_err)
             .and_then(timestamp)?,
-        st_ctim: hostcalls_impl::change_time(file)
+        st_ctim: hostcalls_impl::change_time(file, &metadata)
             .map_err(convert_err)?
             .try_into()
             .map_err(|_| host::__WASI_EOVERFLOW)?, // i64 doesn't fit into u64
@@ -775,7 +775,7 @@ fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_filestat_t>
             .modified()
             .map_err(convert_err)
             .and_then(timestamp)?,
-        st_filetype: hostcalls_impl::filetype(file).map_err(convert_err)?,
+        st_filetype: hostcalls_impl::filetype(&metadata).map_err(convert_err)?,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod ctx;
 mod fdentry;
+mod helpers;
 mod hostcalls_impl;
 mod sys;
 #[macro_use]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -6,17 +6,27 @@ cfg_if! {
         mod unix;
         pub use self::unix::*;
 
-        pub fn errno_from_host(err: i32) -> host::__wasi_errno_t {
+        pub(crate) fn errno_from_host(err: i32) -> host::__wasi_errno_t {
             host_impl::errno_from_nix(nix::errno::from_i32(err))
         }
     } else if #[cfg(windows)] {
         mod windows;
         pub use self::windows::*;
 
-        pub fn errno_from_host(err: i32) -> host::__wasi_errno_t {
+        pub(crate) fn errno_from_host(err: i32) -> host::__wasi_errno_t {
             host_impl::errno_from_win(winx::winerror::WinError::from_u32(err as u32))
         }
     } else {
         compile_error!("wasi-common doesn't compile for this platform yet");
+    }
+}
+
+pub(crate) fn errno_from_ioerror(e: std::io::Error) -> host::__wasi_errno_t {
+    match e.raw_os_error() {
+        Some(code) => errno_from_host(code),
+        None => {
+            log::debug!("Inconvertible OS error: {}", e);
+            host::__WASI_EIO
+        }
     }
 }

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -10,9 +10,9 @@ use crate::{host, wasm32, Result};
 use nix::libc::{self, c_long, c_void, off_t};
 use std::ffi::CString;
 use std::fs::File;
+use std::io;
 use std::os::unix::fs::FileExt;
 use std::os::unix::prelude::{AsRawFd, FromRawFd};
-use std::io;
 
 pub(crate) fn fd_pread(
     file: &File,
@@ -396,10 +396,10 @@ pub(crate) fn filetype(file: &File) -> io::Result<host::__wasi_filetype_t> {
     Ok(ret)
 }
 
-pub(crate) fn change_time(file: &File) -> io::Result<u64> {
-    use std::os::unix::fs::MetadataExt;
+pub(crate) fn change_time(file: &File) -> io::Result<i64> {
     use std::convert::TryInto;
-    Ok(file.metadata()?.ctime().try_into().unwrap())
+    use std::os::unix::fs::MetadataExt;
+    Ok(file.metadata()?.ctime())
 }
 
 pub(crate) fn fd_filestat_set_times(

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -9,7 +9,7 @@ use crate::sys::host_impl;
 use crate::{host, wasm32, Result};
 use nix::libc::{self, c_long, c_void, off_t};
 use std::ffi::CString;
-use std::fs::File;
+use std::fs::{File, Metadata};
 use std::io;
 use std::os::unix::fs::FileExt;
 use std::os::unix::prelude::{AsRawFd, FromRawFd};
@@ -357,24 +357,24 @@ pub(crate) fn path_rename(
     }
 }
 
-pub(crate) fn num_hardlinks(file: &File) -> io::Result<u64> {
+pub(crate) fn num_hardlinks(_file: &File, metadata: &Metadata) -> io::Result<u64> {
     use std::os::unix::fs::MetadataExt;
-    Ok(file.metadata()?.nlink())
+    Ok(metadata.nlink())
 }
 
-pub(crate) fn device_id(file: &File) -> io::Result<u64> {
+pub(crate) fn device_id(_file: &File, metadata: &Metadata) -> io::Result<u64> {
     use std::os::unix::fs::MetadataExt;
-    Ok(file.metadata()?.dev())
+    Ok(metadata.dev())
 }
 
-pub(crate) fn file_serial_no(file: &File) -> io::Result<u64> {
+pub(crate) fn file_serial_no(_file: &File, metadata: &Metadata) -> io::Result<u64> {
     use std::os::unix::fs::MetadataExt;
-    Ok(file.metadata()?.ino())
+    Ok(metadata.ino())
 }
 
-pub(crate) fn filetype(file: &File) -> io::Result<host::__wasi_filetype_t> {
+pub(crate) fn filetype(metadata: &Metadata) -> io::Result<host::__wasi_filetype_t> {
     use std::os::unix::fs::FileTypeExt;
-    let ftype = file.metadata()?.file_type();
+    let ftype = metadata.file_type();
     let ret = if ftype.is_file() {
         host::__WASI_FILETYPE_REGULAR_FILE
     } else if ftype.is_dir() {
@@ -396,10 +396,9 @@ pub(crate) fn filetype(file: &File) -> io::Result<host::__wasi_filetype_t> {
     Ok(ret)
 }
 
-pub(crate) fn change_time(file: &File) -> io::Result<i64> {
-    use std::convert::TryInto;
+pub(crate) fn change_time(_file: &File, metadata: &Metadata) -> io::Result<i64> {
     use std::os::unix::fs::MetadataExt;
-    Ok(file.metadata()?.ctime())
+    Ok(metadata.ctime())
 }
 
 pub(crate) fn fd_filestat_set_times(

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -7,7 +7,7 @@ use crate::sys::errno_from_host;
 use crate::sys::fdentry_impl::determine_type_rights;
 use crate::sys::host_impl;
 use crate::{host, Result};
-use std::fs::File;
+use std::fs::{File, Metadata};
 use std::io::{self, Seek, SeekFrom};
 use std::os::windows::fs::FileExt;
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle};
@@ -173,15 +173,15 @@ pub(crate) fn path_rename(
     unimplemented!("path_rename")
 }
 
-pub(crate) fn num_hardlinks(file: &File) -> io::Result<u64> {
+pub(crate) fn num_hardlinks(file: &File, _metadata: &Metadata) -> io::Result<u64> {
     Ok(winx::file::get_fileinfo(file)?.nNumberOfLinks.into())
 }
 
-pub(crate) fn device_id(file: &File) -> io::Result<u64> {
+pub(crate) fn device_id(file: &File, _metadata: &Metadata) -> io::Result<u64> {
     Ok(winx::file::get_fileinfo(file)?.dwVolumeSerialNumber.into())
 }
 
-pub(crate) fn file_serial_no(file: &File) -> io::Result<u64> {
+pub(crate) fn file_serial_no(file: &File, _metadata: &Metadata) -> io::Result<u64> {
     let info = winx::file::get_fileinfo(file)?;
     let high = info.nFileIndexHigh;
     let low = info.nFileIndexLow;
@@ -189,12 +189,12 @@ pub(crate) fn file_serial_no(file: &File) -> io::Result<u64> {
     Ok(no)
 }
 
-pub(crate) fn change_time(file: &File) -> io::Result<i64> {
+pub(crate) fn change_time(file: &File, _metadata: &Metadata) -> io::Result<i64> {
     winx::file::change_time(file)
 }
 
-pub(crate) fn filetype(file: &File) -> io::Result<host::__wasi_filetype_t> {
-    let ftype = file.metadata()?.file_type();
+pub(crate) fn filetype(metadata: &Metadata) -> io::Result<host::__wasi_filetype_t> {
+    let ftype = metadata.file_type();
     let ret = if ftype.is_file() {
         host::__WASI_FILETYPE_REGULAR_FILE
     } else if ftype.is_dir() {

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -189,7 +189,7 @@ pub(crate) fn file_serial_no(file: &File) -> io::Result<u64> {
     Ok(no)
 }
 
-pub(crate) fn change_time(file: &File) -> io::Result<u64> {
+pub(crate) fn change_time(file: &File) -> io::Result<i64> {
     winx::file::change_time(file)
 }
 

--- a/winx/src/file.rs
+++ b/winx/src/file.rs
@@ -1,9 +1,11 @@
 #![allow(non_camel_case_types)]
 use crate::{winerror, Result};
-use std::ffi::{OsStr, OsString};
-use std::os::windows::prelude::{OsStrExt, OsStringExt, RawHandle};
+use std::ffi::{c_void, OsStr, OsString};
+use std::fs::File;
+use std::io;
+use std::os::windows::prelude::{AsRawHandle, OsStrExt, OsStringExt, RawHandle};
 use winapi::shared::minwindef::{self, DWORD};
-use winapi::um::{fileapi, fileapi::GetFileType, winbase, winnt};
+use winapi::um::{fileapi, fileapi::GetFileType, minwinbase, winbase, winnt};
 
 /// Maximum total path length for Unicode in Windows.
 /// [Maximum path length limitation]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation
@@ -456,4 +458,50 @@ pub fn openat<S: AsRef<OsStr>>(
     } else {
         Ok(handle)
     }
+}
+
+// Taken from Rust libstd, file libstd/sys/windows/fs.rs
+fn cvt(i: winapi::shared::minwindef::BOOL) -> io::Result<()> {
+    if i == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn get_fileinfo(file: &File) -> io::Result<fileapi::BY_HANDLE_FILE_INFORMATION> {
+    use fileapi::{GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION};
+    use std::mem;
+
+    let handle = file.as_raw_handle();
+    let info = unsafe {
+        let mut info: BY_HANDLE_FILE_INFORMATION = mem::zeroed();
+        cvt(GetFileInformationByHandle(handle, &mut info))?;
+        info
+    };
+
+    Ok(info)
+}
+
+pub fn change_time(file: &File) -> io::Result<u64> {
+    use fileapi::FILE_BASIC_INFO;
+    use minwinbase::FileBasicInfo;
+    use std::convert::TryInto;
+    use std::mem;
+    use winbase::GetFileInformationByHandleEx;
+
+    let handle = file.as_raw_handle();
+    let tm = unsafe {
+        let mut info: FILE_BASIC_INFO = mem::zeroed();
+        let infosize = mem::size_of_val(&info);
+        cvt(GetFileInformationByHandleEx(
+            handle,
+            FileBasicInfo,
+            &mut info as *mut FILE_BASIC_INFO as *mut c_void,
+            infosize as u32,
+        ))?;
+        *info.ChangeTime.QuadPart()
+    };
+
+    Ok(tm.try_into().expect("overflow"))
 }

--- a/winx/src/file.rs
+++ b/winx/src/file.rs
@@ -483,10 +483,9 @@ pub fn get_fileinfo(file: &File) -> io::Result<fileapi::BY_HANDLE_FILE_INFORMATI
     Ok(info)
 }
 
-pub fn change_time(file: &File) -> io::Result<u64> {
+pub fn change_time(file: &File) -> io::Result<i64> {
     use fileapi::FILE_BASIC_INFO;
     use minwinbase::FileBasicInfo;
-    use std::convert::TryInto;
     use std::mem;
     use winbase::GetFileInformationByHandleEx;
 
@@ -503,5 +502,5 @@ pub fn change_time(file: &File) -> io::Result<u64> {
         *info.ChangeTime.QuadPart()
     };
 
-    Ok(tm.try_into().expect("overflow"))
+    Ok(tm)
 }


### PR DESCRIPTION
Current issues/doubts about this PR:
* On Windows, we make multiple syscalls for every call of `fd_filestat_get`. Anyway, so as to implement this function efficiently, we need to move a large part of the functionality to libstd, so I prefer code cleanliness over performance for now in this change
* I'm not sure what to do with integer overflows/failed conversions between various types (currently I'm using `try_into` and panic if the conversion fails)
* `file_allocate` fails on Windows for no clear reason: http://paste.debian.net/1092902/ (this paste will expire in 90d) and it seems not to be connected with my change - it looks like the tests crashes during https://github.com/CraneStation/wasi-misc-tests/blob/9f8c648fb14afc1ed9d2effa2567870d65cbc902/src/bin/file_allocate.rs#L91