### PR TITLE
 Implement fd_filestat_set_times using the filetime crate. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 rand = "0.6"
 cfg-if = "0.1.9"
 log = "0.4"
-filetime = "0.2.6"
+filetime = "0.2.7"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2"
 rand = "0.6"
 cfg-if = "0.1.9"
 log = "0.4"
+filetime = "0.2.6"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.13"

--- a/build.rs
+++ b/build.rs
@@ -136,7 +136,6 @@ cfg_if::cfg_if! {
                     "symlink_loop" => true,
                     "clock_time_get" => true,
                     "truncation_rights" => true,
-                    "fd_filestat_set" => true,
                     _ => false,
                 }
             } else {

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -766,10 +766,10 @@ pub(crate) fn fd_filestat_set_times(
     let st_mtim = dec_timestamp(st_mtim);
     let fst_flags = dec_fstflags(fst_flags);
 
-    let set_atim = fst_flags & host::__WASI_FILESTAT_SET_MTIM != 0;
-    let set_atim_now = fst_flags & host::__WASI_FILESTAT_SET_MTIM != 0;
+    let set_atim = fst_flags & host::__WASI_FILESTAT_SET_ATIM != 0;
+    let set_atim_now = fst_flags & host::__WASI_FILESTAT_SET_ATIM_NOW != 0;
     let set_mtim = fst_flags & host::__WASI_FILESTAT_SET_MTIM != 0;
-    let set_mtim_now = fst_flags & host::__WASI_FILESTAT_SET_MTIM != 0;
+    let set_mtim_now = fst_flags & host::__WASI_FILESTAT_SET_MTIM_NOW != 0;
 
     if (set_atim && set_atim_now) || (set_mtim && set_mtim_now) {
         return Err(host::__WASI_EINVAL);

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -6,7 +6,7 @@ use crate::hostcalls_impl::PathGet;
 use crate::sys::errno_from_ioerror;
 use crate::sys::host_impl;
 use crate::{host, wasm32, Result};
-use nix::libc::{self, c_long, c_void, off_t};
+use nix::libc::{self, c_long, c_void};
 use std::convert::TryInto;
 use std::ffi::CString;
 use std::fs::{File, Metadata};
@@ -50,6 +50,8 @@ pub(crate) fn fd_advise(
 ) -> Result<()> {
     #[cfg(target_os = "linux")]
     {
+        use nix::libc::off_t;
+
         let host_advice = match advice {
             host::__WASI_ADVICE_DONTNEED => libc::POSIX_FADV_DONTNEED,
             host::__WASI_ADVICE_SEQUENTIAL => libc::POSIX_FADV_SEQUENTIAL,

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -267,15 +267,6 @@ fn filetype(metadata: &Metadata) -> io::Result<host::__wasi_filetype_t> {
     Ok(ret)
 }
 
-pub(crate) fn fd_filestat_set_times(
-    fd: &File,
-    st_atim: host::__wasi_timestamp_t,
-    mut st_mtim: host::__wasi_timestamp_t,
-    fst_flags: host::__wasi_fstflags_t,
-) -> Result<()> {
-    unimplemented!("fd_filestat_set_times")
-}
-
 pub(crate) fn path_filestat_get(
     resolved: PathGet,
     dirflags: host::__wasi_lookupflags_t,


### PR DESCRIPTION
In the future we could consider using `filetime` to replace `systemtime_to_timestamp` from #42.