### PR TITLE
Add path_rename implementation on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -136,7 +136,6 @@ cfg_if::cfg_if! {
                     "symlink_loop" => true,
                     "clock_time_get" => true,
                     "truncation_rights" => true,
-                    "path_rename" => true,
                     _ => false,
                 }
             } else {


### PR DESCRIPTION
This PR adds `path_rename` implementation on Windows. It depends on #57 to be merged first.

The implementation handles and is tested against all cases listed in CraneStation/wasi-misc-tests#17. However, checks that symlinks and links are handled properly are still missing, but I reckon we can do that in a future PR when we add a testcase testing such a scenario.