### PR TITLE
Miscellaneous refactoring

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -110,7 +110,7 @@ impl WasiCtxBuilder {
             .into_iter()
             .map(|(k, v)| {
                 let mut pair = k.into_bytes();
-                pair.extend_from_slice(b"=");
+                pair.push(b'=');
                 pair.extend_from_slice(v.to_bytes_with_nul());
                 // constructing a new CString from existing CStrings is safe
                 unsafe { CString::from_vec_unchecked(pair) }

--- a/src/hostcalls_impl/fs_helpers.rs
+++ b/src/hostcalls_impl/fs_helpers.rs
@@ -61,7 +61,7 @@ pub(crate) fn path_get(
             Some(cur_path) => {
                 log::debug!("cur_path = {:?}", cur_path);
 
-                let ends_with_slash = cur_path.ends_with("/");
+                let ends_with_slash = cur_path.ends_with('/');
                 let mut components = Path::new(&cur_path).components();
                 let head = match components.next() {
                     None => return Err(host::__WASI_ENOENT),
@@ -72,7 +72,7 @@ pub(crate) fn path_get(
                 if tail.components().next().is_some() {
                     let mut tail = host_impl::path_from_host(tail.as_os_str())?;
                     if ends_with_slash {
-                        tail.push_str("/");
+                        tail.push('/');
                     }
                     path_stack.push(tail);
                 }
@@ -98,7 +98,7 @@ pub(crate) fn path_get(
                         let mut head = host_impl::path_from_host(head)?;
                         if ends_with_slash {
                             // preserve trailing slash
-                            head.push_str("/");
+                            head.push('/');
                         }
 
                         if !path_stack.is_empty() || (ends_with_slash && !needs_final_component) {
@@ -124,8 +124,8 @@ pub(crate) fn path_get(
                                         return Err(host::__WASI_ELOOP);
                                     }
 
-                                    if head.ends_with("/") {
-                                        link_path.push_str("/");
+                                    if head.ends_with('/') {
+                                        link_path.push('/');
                                     }
 
                                     log::debug!(
@@ -156,8 +156,8 @@ pub(crate) fn path_get(
                                         return Err(host::__WASI_ELOOP);
                                     }
 
-                                    if head.ends_with("/") {
-                                        link_path.push_str("/");
+                                    if head.ends_with('/') {
+                                        link_path.push('/');
                                     }
 
                                     log::debug!(

--- a/src/sys/windows/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/windows/hostcalls_impl/fs_helpers.rs
@@ -86,9 +86,9 @@ pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<String> {
                 log::debug!("readlinkat error={:?}", e);
                 match WinError::from_u32(e as u32) {
                     WinError::ERROR_INVALID_NAME => {
-                        if s_path.ends_with("/") {
+                        if s_path.ends_with('/') {
                             // strip "/" and check if exists
-                            let path = concatenate(dirfd, Path::new(s_path.trim_end_matches("/")))?;
+                            let path = concatenate(dirfd, Path::new(s_path.trim_end_matches('/')))?;
                             if path.exists() && !path.is_dir() {
                                 Err(host::__WASI_ENOTDIR)
                             } else {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -6,15 +6,8 @@ use std::io::prelude::*;
 use std::path::{Component, Path};
 use std::time::SystemTime;
 
-fn read_to_end<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, io::Error> {
-    let mut buf: Vec<u8> = Vec::new();
-    let mut file = File::open(path)?;
-    file.read_to_end(&mut buf)?;
-    Ok(buf)
-}
-
 pub fn read_wasm<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, String> {
-    let data = read_to_end(path).map_err(|err| err.to_string())?;
+    let data = fs::read(path).map_err(|err| err.to_string())?;
     if data.starts_with(&[b'\0', b'a', b's', b'm']) {
         Ok(data)
     } else {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,8 +1,6 @@
 use std::env;
 use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io;
-use std::io::prelude::*;
+use std::fs;
 use std::path::{Component, Path};
 use std::time::SystemTime;
 


### PR DESCRIPTION
This just collects a few miscellanous refactorings I've collected while reviewing other changes.
 - Use char/byte literals instead of single-char/byte string literals.
 - Minor simplifications to `get_path_by_handle`.
 - Use `fs::read` instead of doing it manually.
