### PR TITLE
Implement fd_readdir on Unix with nix & on Windows with libstd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 **/*.rs.bk
 .DS_Store
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 filetime = "0.2.7"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.15"
+nix = { git = "https://github.com/marmistrz/nix", branch = "seek" }
 
 [target.'cfg(windows)'.dependencies]
 winx = { path = "winx" }

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -1120,7 +1120,7 @@ impl Dirent {
             *sys_dirent = host::__wasi_dirent_t {
                 d_namlen: namlen.try_into().map_err(|_| host::__WASI_EOVERFLOW)?,
                 d_ino: self.ino,
-                d_next: self.cookie, // fixme cast
+                d_next: self.cookie,
                 d_type: self.ftype.to_wasi(),
             };
         }

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -1093,12 +1093,12 @@ impl FileType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Dirent {
     pub name: String,
     pub ftype: FileType,
     pub ino: u64,
-    pub cookie: nix::dir::SeekLoc,
+    pub cookie: host::__wasi_dircookie_t,
 }
 
 impl Dirent {
@@ -1120,7 +1120,7 @@ impl Dirent {
             *sys_dirent = host::__wasi_dirent_t {
                 d_namlen: namlen.try_into().map_err(|_| host::__WASI_EOVERFLOW)?,
                 d_ino: self.ino,
-                d_next: self.cookie.to_raw() as u64, // fixme cast
+                d_next: self.cookie, // fixme cast
                 d_type: self.ftype.to_wasi(),
             };
         }

--- a/src/sys/unix/fdentry_impl.rs
+++ b/src/sys/unix/fdentry_impl.rs
@@ -51,10 +51,7 @@ pub(crate) fn determine_type_rights<Fd: AsRawFd>(
         // we just make a `File` here for convenience; we don't want it to close when it drops
         let file =
             std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(fd.as_raw_fd()) });
-        let ft = file
-            .metadata()
-            .map_err(errno_from_ioerror)?
-            .file_type();
+        let ft = file.metadata().map_err(errno_from_ioerror)?.file_type();
         if ft.is_block_device() {
             (
                 host::__WASI_FILETYPE_BLOCK_DEVICE,
@@ -110,9 +107,9 @@ pub(crate) fn determine_type_rights<Fd: AsRawFd>(
             }
         } else if ft.is_fifo() {
             (
-                host::__WASI_FILETYPE_SOCKET_STREAM,
-                host::RIGHTS_SOCKET_BASE,
-                host::RIGHTS_SOCKET_INHERITING,
+                host::__WASI_FILETYPE_UNKNOWN,
+                host::RIGHTS_REGULAR_FILE_BASE,
+                host::RIGHTS_REGULAR_FILE_INHERITING,
             )
         } else {
             return Err(host::__WASI_EINVAL);

--- a/src/sys/unix/host_impl.rs
+++ b/src/sys/unix/host_impl.rs
@@ -158,7 +158,7 @@ pub(crate) fn filetype_from_nix(sflags: nix::sys::stat::SFlag) -> host::__wasi_f
         host::__WASI_FILETYPE_CHARACTER_DEVICE
     } else if sflags.contains(SFlag::S_IFBLK) {
         host::__WASI_FILETYPE_BLOCK_DEVICE
-    } else if sflags.contains(SFlag::S_IFIFO) | sflags.contains(SFlag::S_IFSOCK) {
+    } else if sflags.contains(SFlag::S_IFSOCK) {
         host::__WASI_FILETYPE_SOCKET_STREAM
     } else if sflags.contains(SFlag::S_IFDIR) {
         host::__WASI_FILETYPE_DIRECTORY
@@ -169,31 +169,6 @@ pub(crate) fn filetype_from_nix(sflags: nix::sys::stat::SFlag) -> host::__wasi_f
     } else {
         host::__WASI_FILETYPE_UNKNOWN
     }
-}
-
-pub(crate) fn nix_from_filetype(sflags: host::__wasi_filetype_t) -> nix::sys::stat::SFlag {
-    use nix::sys::stat::SFlag;
-    let mut nix_sflags = SFlag::empty();
-    if sflags & host::__WASI_FILETYPE_CHARACTER_DEVICE != 0 {
-        nix_sflags.insert(SFlag::S_IFCHR);
-    }
-    if sflags & host::__WASI_FILETYPE_BLOCK_DEVICE != 0 {
-        nix_sflags.insert(SFlag::S_IFBLK);
-    }
-    if sflags & host::__WASI_FILETYPE_SOCKET_STREAM != 0 {
-        nix_sflags.insert(SFlag::S_IFIFO);
-        nix_sflags.insert(SFlag::S_IFSOCK);
-    }
-    if sflags & host::__WASI_FILETYPE_DIRECTORY != 0 {
-        nix_sflags.insert(SFlag::S_IFDIR);
-    }
-    if sflags & host::__WASI_FILETYPE_REGULAR_FILE != 0 {
-        nix_sflags.insert(SFlag::S_IFREG);
-    }
-    if sflags & host::__WASI_FILETYPE_SYMBOLIC_LINK != 0 {
-        nix_sflags.insert(SFlag::S_IFLNK);
-    }
-    nix_sflags
 }
 
 pub(crate) fn filestat_from_nix(

--- a/src/sys/unix/host_impl.rs
+++ b/src/sys/unix/host_impl.rs
@@ -86,6 +86,10 @@ pub(crate) fn errno_from_nix(errno: nix::errno::Errno) -> host::__wasi_errno_t {
     }
 }
 
+pub(crate) fn errno_from_nixerror(err: nix::Error) -> host::__wasi_errno_t {
+    err.as_errno().map_or(host::__WASI_ENOSYS, errno_from_nix)
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_RSYNC;
 

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -257,8 +257,8 @@ pub(crate) fn fd_readdir(fd: &File, cookie: host::__wasi_dircookie_t) -> Result<
             Ok(Dirent {
                 name: dir.file_name().to_string_lossy().into_owned(), // fixme utf8
                 ino: dir.ino(),
-                ftype: filetype_from_nixdir(dir.file_type()),
-                cookie: dir.seek_loc(),
+                ftype: filetype_from_nixdir(dir.file_type()), // fixme use From<_>
+                cookie: dir.seek_loc().to_raw() as u64, // fixme cast
             })
         })
         .collect()

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -254,10 +254,7 @@ pub(crate) fn fd_readdir(fd: &File, cookie: host::__wasi_dircookie_t) -> Result<
         dir.seek(loc);
     }
 
-    // TODO nix::dir::Iter calls rewinddir in drop(), but we can't use
-    // ManuallyDrop because moving out of borrowed context
-    // Should we just add an option in nix not to rewind at the end??
-    dir.iter()
+    dir.iter_norewind()
         .map(|dir| {
             let dir: Entry = dir.map_err(errno_from_nixerror)?;
             Ok(Dirent {

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -5,7 +5,7 @@ use crate::helpers::systemtime_to_timestamp;
 use crate::hostcalls_impl::{Dirent, FileType, PathGet};
 use crate::sys::errno_from_ioerror;
 use crate::sys::host_impl::{self, errno_from_nixerror};
-use crate::{host, wasm32, Result};
+use crate::{host, Result};
 use log::trace;
 use nix::libc;
 use std::convert::TryInto;

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -344,8 +344,8 @@ pub(crate) fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_
 }
 
 fn filetype(file: &File, metadata: &Metadata) -> Result<host::__wasi_filetype_t> {
-    use std::os::unix::fs::FileTypeExt;
     use nix::sys::socket::{self, SockType};
+    use std::os::unix::fs::FileTypeExt;
     let ftype = metadata.file_type();
     if ftype.is_file() {
         Ok(host::__WASI_FILETYPE_REGULAR_FILE)
@@ -357,15 +357,15 @@ fn filetype(file: &File, metadata: &Metadata) -> Result<host::__wasi_filetype_t>
         Ok(host::__WASI_FILETYPE_CHARACTER_DEVICE)
     } else if ftype.is_block_device() {
         Ok(host::__WASI_FILETYPE_BLOCK_DEVICE)
-    } else if ftype.is_fifo() {
-        Ok(host::__WASI_FILETYPE_SOCKET_STREAM)
     } else if ftype.is_socket() {
-        match socket::getsockopt(file.as_raw_fd(), socket::sockopt::SockType).map_err(|err|
-            err.as_errno().unwrap()).map_err(host_impl::errno_from_nix)? {
-                SockType::Datagram => Ok(host::__WASI_FILETYPE_SOCKET_DGRAM),
-                SockType::Stream => Ok(host::__WASI_FILETYPE_SOCKET_STREAM),
-                _ => Ok(host::__WASI_FILETYPE_UNKNOWN),
-            }
+        match socket::getsockopt(file.as_raw_fd(), socket::sockopt::SockType)
+            .map_err(|err| err.as_errno().unwrap())
+            .map_err(host_impl::errno_from_nix)?
+        {
+            SockType::Datagram => Ok(host::__WASI_FILETYPE_SOCKET_DGRAM),
+            SockType::Stream => Ok(host::__WASI_FILETYPE_SOCKET_STREAM),
+            _ => Ok(host::__WASI_FILETYPE_UNKNOWN),
+        }
     } else {
         Ok(host::__WASI_FILETYPE_UNKNOWN)
     }

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -267,7 +267,7 @@ pub(crate) fn fd_readdir(fd: &File, cookie: host::__wasi_dircookie_t) -> Result<
                     .map_err(|_| host::__WASI_EILSEQ)?
                     .to_owned(),
                 ino: dir.ino(),
-                ftype: filetype_from_nixdir(dir.file_type()), // TODO use From<_> conversions
+                ftype: filetype_from_nixdir(dir.file_type()),
                 cookie: dir
                     .seek_loc()
                     .to_raw()

--- a/src/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -57,9 +57,7 @@ pub(crate) fn readlinkat(dirfd: &File, path: &str) -> Result<String> {
     use nix::fcntl;
     use std::os::unix::prelude::AsRawFd;
 
-    let readlink_buf = &mut [0u8; libc::PATH_MAX as usize + 1];
-
-    fcntl::readlinkat(dirfd.as_raw_fd(), path, readlink_buf)
+    fcntl::readlinkat(dirfd.as_raw_fd(), path)
         .map_err(|e| host_impl::errno_from_nix(e.as_errno().unwrap()))
         .and_then(host_impl::path_from_host)
 }

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -172,7 +172,9 @@ fn dirent_from_path<P: AsRef<Path>>(
     let file = OpenOptions::new()
         .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
         .open(path)?;
+    trace!("Getting metadata");
     let ty = file.metadata()?.file_type();
+    trace!("Getting file serial no");
     Ok(Dirent {
         ftype: filetype_from_std(&ty),
         name: String::new(),

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -177,7 +177,7 @@ pub(crate) fn fd_readdir(fd: &File, cookie: host::__wasi_dircookie_t) -> Result<
     use winx::file::get_path_by_handle;
 
     // TODO document caveats and the order assumptions
-
+    let cookie = cookie.try_into().map_err(|_| host::__WASI_EOVERFLOW)?;
     let path = get_path_by_handle(fd.as_raw_handle()).map_err(host_impl::errno_from_win)?;
     // std::fs::ReadDir doesn't return . and .., so we need to emulate it
     let path = Path::new(&path);
@@ -209,7 +209,7 @@ pub(crate) fn fd_readdir(fd: &File, cookie: host::__wasi_dircookie_t) -> Result<
 
     // Emulate seekdir(). This may give O(n^2) TODO explain why
     // TODO explain why it's the least evil
-    iter.skip(cookie as usize).collect() //fixme cast
+    iter.skip(cookie).collect() //fixme cast
 }
 
 pub(crate) fn path_readlink(resolved: PathGet, buf: &mut [u8]) -> Result<usize> {

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -4,6 +4,7 @@ use super::fs_helpers::*;
 use crate::ctx::WasiCtx;
 use crate::fdentry::FdEntry;
 use crate::helpers::systemtime_to_timestamp;
+use crate::hostcalls_impl::Dirent;
 use crate::hostcalls_impl::{fd_filestat_set_times_impl, PathGet};
 use crate::sys::fdentry_impl::determine_type_rights;
 use crate::sys::host_impl;
@@ -11,7 +12,7 @@ use crate::sys::hostcalls_impl::fs_helpers::PathGetExt;
 use crate::sys::{errno_from_host, errno_from_ioerror};
 use crate::{host, Result};
 use std::convert::TryInto;
-use std::fs::{File, Metadata, OpenOptions};
+use std::fs::{File, FileType, Metadata, OpenOptions};
 use std::io::{self, Seek, SeekFrom};
 use std::mem;
 use std::os::windows::fs::{FileExt, OpenOptionsExt};
@@ -161,36 +162,32 @@ pub(crate) fn fd_readdir(
     fd: &File,
     mut host_buf: &mut [u8],
     cookie: host::__wasi_dircookie_t,
-) -> Result<usize> {
+) -> Result<Vec<Dirent>> {
     use host_impl::path_from_host;
     use winx::file::get_path_by_handle;
 
     assert_eq!(cookie, 0, "non-zero cookie not supported yet!!");
     let path = get_path_by_handle(fd.as_raw_handle()).map_err(host_impl::errno_from_win)?;
-    let readdir = Path::new(&path).read_dir().map_err(errno_from_ioerror)?;
+    Path::new(&path)
+        .read_dir()
+        .map_err(errno_from_ioerror)?
+        .map(|dir| {
+            let dir: std::fs::DirEntry = dir.map_err(errno_from_ioerror)?;
+
+            let name = dir.file_name();
+            Ok(Dirent {
+                name: path_from_host(dir.file_name())?,
+                ftype: dir.file_type().map_err(errno_from_ioerror)?,
+                ino: File::open(dir.path())
+                    .and_then(|f| file_serial_no(&f))
+                    .map_err(errno_from_ioerror)?,
+            })
+        })
+        .collect()
 
     // The code from now on could be mostly reused on Linux, but ReadDir implementation
     // requires us to have a root Path
-    let mut used = 0;
-    for dir in readdir {
-        let dir: std::fs::DirEntry = dir.map_err(errno_from_ioerror)?;
-
-        let name = dir.file_name();
-        let dirent = Dirent {
-            name: path_from_host(dir.file_name())?,
-            ftype: dir.file_type().map_err(errno_from_ioerror)?,
-            ino: File::open(dir.path())
-                .and_then(|f| file_serial_no(&f))
-                .map_err(errno_from_ioerror)?,
-        };
-        let dirent_raw = dirent.to_raw()?;
-        let offset = dirent_raw.len();
-        host_buf[0..offset].copy_from_slice(&dirent_raw);
-        used += offset;
-        host_buf = &mut host_buf[offset..];
-    }
-
-    Ok(used)
+    /**/
 }
 
 pub(crate) fn path_readlink(resolved: PathGet, buf: &mut [u8]) -> Result<usize> {
@@ -318,13 +315,12 @@ pub(crate) fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_
             .modified()
             .map_err(errno_from_ioerror)
             .and_then(systemtime_to_timestamp)?,
-        st_filetype: filetype(file, &metadata)?,
+        st_filetype: filetype_from_std(&metadata.file_type()),
     })
 }
 
-fn filetype(_file: &File, metadata: &Metadata) -> Result<host::__wasi_filetype_t> {
-    let ftype = metadata.file_type();
-    let ret = if ftype.is_file() {
+pub(crate) fn filetype_from_std(ftype: &FileType) -> host::__wasi_filetype_t {
+    if ftype.is_file() {
         host::__WASI_FILETYPE_REGULAR_FILE
     } else if ftype.is_dir() {
         host::__WASI_FILETYPE_DIRECTORY
@@ -332,9 +328,7 @@ fn filetype(_file: &File, metadata: &Metadata) -> Result<host::__wasi_filetype_t
         host::__WASI_FILETYPE_SYMBOLIC_LINK
     } else {
         host::__WASI_FILETYPE_UNKNOWN
-    };
-
-    Ok(ret)
+    }
 }
 
 pub(crate) fn path_filestat_get(

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -163,12 +163,13 @@ fn dirent_from_path<P: AsRef<Path>>(
     path: P,
     cookie: host::__wasi_dircookie_t,
 ) -> io::Result<Dirent> {
+    trace!("dirent_from_path: opening {}", path.as_ref().to_string_lossy());
     let file = File::open(path)?;
     let ty = file.metadata()?.file_type();
     Ok(Dirent {
         ftype: filetype_from_std(&ty),
         name: String::new(),
-        cookie: 0,
+        cookie,
         ino: file_serial_no(&file)?,
     })
 }

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -11,6 +11,7 @@ use crate::sys::host_impl;
 use crate::sys::hostcalls_impl::fs_helpers::PathGetExt;
 use crate::sys::{errno_from_host, errno_from_ioerror};
 use crate::{host, Result};
+use log::{debug, trace};
 use std::convert::TryInto;
 use std::fs::{File, Metadata, OpenOptions};
 use std::io::{self, Seek, SeekFrom};
@@ -183,9 +184,11 @@ pub(crate) fn fd_readdir(fd: &File, cookie: host::__wasi_dircookie_t) -> Result<
     let path = Path::new(&path);
     // The directory /.. is the same as / on Unix, so emulate this behavior too
     let parent = path.parent().unwrap_or(path);
-
+    trace!("    | fd_readdir impl: emulating .");
     let dot = dirent_from_path(path, 1).map_err(errno_from_ioerror)?;
+    trace!("    | fd_readdir impl: emulating ..");
     let dotdot = dirent_from_path(parent, 2).map_err(errno_from_ioerror)?;
+    trace!("    | fd_readdir impl: executing std::fs::ReadDir");
     let iter = path
         .read_dir()
         .map_err(errno_from_ioerror)?


### PR DESCRIPTION
Before this can be merged:
* [x] we need to clarify and extend the test in https://github.com/CraneStation/wasi-misc-tests/pull/21. 
* [ ] On Unix, raw `readdir` executed on an empty directory will return two entries: `.` and `..`. On the other hand, `std::fs::read_dir` will return an empty iterator. Should we emulate the behavior of the unix `readdir` syscall in wasi by manually adding `.` and `..`? The current implementation does it but the spec is not clear about this. 
* [ ] we're leaking inode/serial number information about `..`, which may not be preopened and may hence be inaccessible for apps run inside WASI. I don't think it's an issue, but I want to make sure this isn't a vulnerability
* [ ] upstream the changes done for nix (tracking in https://github.com/nix-rust/nix/issues/1110)
* [ ] mac is currently broken
-----
Follow-ups needed:
* Add a heuristic optimization to `fd_readdir` on Windows: the most common use case where seeking may be needed is when the buffer length is insufficient. We could cache the last cookie and the relevant handle for each file descriptor so that the implementation is O(n) and not O(n^2) with O(1) buffer in the most common case
* Add `Into`/`From` conversions for `Filetype` 
* Raise the issues about the spec  of `fd_readdir`:
  * `readdir(3p)` says that 
     > If a file is removed from or added to the directory after the most recent call to  opendir()  or
     > rewinddir(),  whether  a subsequent call to readdir() returns an entry for that file is unspecified.

    We need to add this to spec of `fd_readdir` in some form.
  * discuss how to clarify the semantics of cookie (also that it corresponds to the next entry)
  * mention the similarity to `readdir`/`seekdir` in the docs
  * should the implementation return  `.` & `..`?
  * be precise whether or not the filenames are NULL-terminated (in POSIX they are)
* ~nix uses `readdir_r` which is deprecated in `readdir_r(3)`. Raise an issue and discuss whether or not `readdir` should be used instead (at least on Linux)~ https://github.com/rust-lang/rust/issues/34668
-------
**Implementation notes:**
The code written using libstd could be mostly reused for Linux, but:
* (first and foremost) this would force us to emulate entries for `.` & `..`, which would cost us extra syscalls on Linux
* accessors for `file_serial_no` not stable yet: https://github.com/rust-lang/rust/issues/63010
* `ReadDir` from `libstd` requires to have a `Path` for no real reason.

While we could technically either hack the `std::fs::ReadDir` using unsafe code (transmute) or fork it, I believe that the overhead of adding at least two (and probably at least four) extra syscalls 

`ReadDir` can only be constructed from a root path for the directory query.

On Unix, the path is only used for `impl Debug` and `fn path`. In other words, `fd_readdir` could be implemented completely using `std::fs::ReadDir` if we just removed every reference to the root path in the code and created it from a `&File` instead. Unfortunately, this wouldn't be a backwards compatible change in libstd, because `fn path` would have to return an `Option<Path>`.

On Windows, while the root path is used in `impl Iterator for ReadDir`, it's only seeming that the restriction is required, since one can recover path from `&File` on Windows. 

Therefore, to all my knowledge it appears that the explicit path could be removed from `ReadDir`, but it would break backwards compatibility, so such a change won't unfortunately be accepted into stdlib.

-------
What are the alternatives?
* we could manually create our own `ReadDir` and then use `std::mem::transmute` to convert it to `std::fs::ReadDir`. While this will work, it is heavily dependent on non-public Rust libstd API and its implementation details. We'd also probably have to do our own wrapper to disallow `DirEntry::path`
* do a copy-paste of `ReadDir` (possibly in a separate crate), dropping the requirement on `Path`. This has the obvious disadvantage of maintaining our own fork but allows us to have a common implementation for Unix & Windows. We can't actually reuse the `readdir` syscall on Unix because of implementation details: on Unix the filenames are null-terminated, on wasi they aren't (cf. the discussion in https://github.com/CraneStation/wasi-misc-tests/pull/21)
* implement `fd_readdir` using `nix` on unix, `ReadDir` on windows.