### PR TITLE
Fixes #30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 filetime = "0.2.7"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.15"
+nix = { git = "https://github.com/nix-rust/nix" }
 
 [target.'cfg(windows)'.dependencies]
 winx = { path = "winx" }

--- a/src/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/src/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -2,7 +2,7 @@
 #![allow(unused_unsafe)]
 use crate::sys::host_impl;
 use crate::{host, Result};
-use nix::libc::{self, c_long};
+use nix::libc::c_long;
 use std::fs::File;
 
 pub(crate) fn path_open_rights(
@@ -57,9 +57,7 @@ pub(crate) fn readlinkat(dirfd: &File, path: &str) -> Result<String> {
     use nix::fcntl;
     use std::os::unix::prelude::AsRawFd;
 
-    let readlink_buf = &mut [0u8; libc::PATH_MAX as usize + 1];
-
-    fcntl::readlinkat(dirfd.as_raw_fd(), path, readlink_buf)
+    fcntl::readlinkat(dirfd.as_raw_fd(), path)
         .map_err(|e| host_impl::errno_from_nix(e.as_errno().unwrap()))
         .and_then(host_impl::path_from_host)
 }


### PR DESCRIPTION
Currently, the fixed version of `readlinkat` is provided in upstream
[nix](https://github.com/nix-rust/nix) crate only, therefore, we
need to change `nix` to be a git dependency, which is not ideal.
However, a new release should be out soon-ish, hence, I reckon it's
OK to go with it as-is for now, and change to a semver when a new
version gets released.

Changes:
* uses `nix::fcntl::readlinkat` instead of a direct call to
  `libc::readlinkat`
* if read target path is longer than the buffer provided,
  pads the buffer with 0s

Kudos to @sendilkumarn for providing a nice fix to `nix` (nix-rust/nix#1109).