### PR TITLE
[WIP] Add missing docs to functions, constants and modules

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,4 @@
-//! WASI host types as defined in host. This file was originally generated
-//! by running bindgen over wasi/core.h, and the content
-//! still largely reflects that.
+//! WASI host types as defined in host.
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 use crate::Result;

--- a/src/hostcalls/fs.rs
+++ b/src/hostcalls/fs.rs
@@ -3,8 +3,40 @@ use crate::ctx::WasiCtx;
 use crate::wasm32;
 
 hostcalls! {
+    /// Close a file descriptor.
+    ///
+    /// Note: this is similar to [`close`] in POSIX.
+    ///
+    /// ## Possible errors
+    /// * [`__WASI_EBADF`]   - The `fd` argument is not a valid file descriptor.
+    /// * [`__WASI_ENOTSUP`] - The `fd` argument is a preopened file descriptor.
+    ///
+    /// [`close`]: https://linux.die.net/man/2/close
+    /// [`__WASI_EBADF`]: ../host/constant.__WASI_EBADF.html
+    /// [`__WASI_ENOTSUP`]: ../host/constant.__WASI_ENOTSUP.html
     pub fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
-
+    /// Synchronize the data of a file to disk.
+    ///
+    /// Note: this is similar to [`fdatasync`] in POSIX.
+    ///
+    /// ## Required rights:
+    /// * [`__WASI_RIGHT_FD_DATASYNC`]
+    ///
+    /// ## Possible errors
+    /// * [`__WASI_EBADF`]                    - The `fd` argument is not a valid file descriptor.
+    /// * [`__WASI_EIO`]                      - An I/O error occurred.
+    /// * [`__WASI_EINVAL`], [`__WASI_EROFS`] - The `fd` is bound to a special file which does not
+    ///                                         support synchronization.
+    /// * [`__WASI_ENOTCAPABLE`]              - The `fd` file descriptor lacks the required rights
+    ///                                         to perform datasync operation.
+    ///
+    /// [`fdatasync`]: https://linux.die.net/man/2/fdatasync
+    /// [`__WASI_RIGHT_FD_DATASYNC`]: ../host/constant.__WASI_RIGHT_FD_DATASYNC.html
+    /// [`__WASI_EBADF`]: ../host/constant.__WASI_EBADF.html
+    /// [`__WASI_EIO`]: ../host/constant.__WASI_EIO.html
+    /// [`__WASI_EINVAL`]: ../host/constant.__WASI_EINVAL.html
+    /// [`__WASI_EROFS`]: ../host/constant.__WASI_EROFS.html
+    /// [`__WASI_ENOTCAPABLE`]: ../host/constant.__WASI_ENOTCAPABLE.html
     pub fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
 
     pub fn fd_pread(

--- a/src/hostcalls/mod.rs
+++ b/src/hostcalls/mod.rs
@@ -1,3 +1,4 @@
+//! WASI system calls.
 mod fs;
 mod misc;
 mod sock;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,10 @@
 macro_rules! hostcalls {
-    ($(pub fn $name:ident($($arg:ident: $ty:ty,)*) -> $ret:ty;)*) => ($(
+    ($(
+            $(#[doc=$doc:literal])*
+            pub fn $name:ident($($arg:ident: $ty:ty,)*) -> $ret:ty;
+    )*) => (
+        $(
+            $(#[doc=$doc])*
             #[wasi_common_cbindgen::wasi_common_cbindgen]
             pub fn $name($($arg: $ty,)*) -> $ret {
                 let ret = match crate::hostcalls_impl::$name($($arg,)*) {
@@ -9,5 +14,6 @@ macro_rules! hostcalls {
 
                 crate::hostcalls::return_enc_errno(ret)
             }
-    )*)
+        )*
+    )
 }

--- a/src/wasm32.rs
+++ b/src/wasm32.rs
@@ -1,10 +1,4 @@
-//! WASI types as defined in wasm32. This file was originally generated
-//! by running bindgen over wasi/core.h with a wasm32 target, and the content
-//! still largely reflects that, however it's been heavily modified, to
-//! be host-independent, to avoid exposing libc implementation details,
-//! to clean up cases where the headers use complex preprocessor macros,
-//! and to
-
+//! WASI types as defined in wasm32.
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]


### PR DESCRIPTION
This PR adds missing docs to functions, constants and modules.

TODO:
- [ ] `hostcalls` module
- [ ] `memory` module
- [ ] constants
- [ ] `WasiCtx` and related 