### PR TITLE
Check for socket type in filetype.

### DIFF
--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -288,11 +288,11 @@ pub(crate) fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_
             .modified()
             .map_err(errno_from_ioerror)
             .and_then(systemtime_to_timestamp)?,
-        st_filetype: filetype(&metadata).map_err(errno_from_ioerror)?,
+        st_filetype: filetype(&metadata)?,
     })
 }
 
-fn filetype(metadata: &Metadata) -> io::Result<host::__wasi_filetype_t> {
+fn filetype(_file: &File, metadata: &Metadata) -> Result<host::__wasi_filetype_t> {
     let ftype = metadata.file_type();
     let ret = if ftype.is_file() {
         host::__WASI_FILETYPE_REGULAR_FILE

--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -288,7 +288,7 @@ pub(crate) fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_
             .modified()
             .map_err(errno_from_ioerror)
             .and_then(systemtime_to_timestamp)?,
-        st_filetype: filetype(&metadata)?,
+        st_filetype: filetype(file, &metadata)?,
     })
 }
 


### PR DESCRIPTION
The signature for Windows has also been changed, so that the function
can be reused in cross-platform modules. 

Unfortunately, this makes `fd_filestat_get` require an extra syscall on Unix, because the data returned by `fstat` doesn't include the information about the socket type.

cc @kubkon 