### PR TITLE
Add a no-op implementation of fd_advise on Windows

### DIFF
--- a/src/sys/windows/hostcalls_impl/fs.rs
+++ b/src/sys/windows/hostcalls_impl/fs.rs
@@ -61,12 +61,22 @@ pub(crate) fn fd_fdstat_set_flags(fd: &File, fdflags: host::__wasi_fdflags_t) ->
 }
 
 pub(crate) fn fd_advise(
-    file: &File,
+    _file: &File,
     advice: host::__wasi_advice_t,
-    offset: host::__wasi_filesize_t,
-    len: host::__wasi_filesize_t,
+    _offset: host::__wasi_filesize_t,
+    _len: host::__wasi_filesize_t,
 ) -> Result<()> {
-    unimplemented!("fd_advise")
+    match advice {
+        host::__WASI_ADVICE_DONTNEED
+        | host::__WASI_ADVICE_SEQUENTIAL
+        | host::__WASI_ADVICE_WILLNEED
+        | host::__WASI_ADVICE_NOREUSE
+        | host::__WASI_ADVICE_RANDOM
+        | host::__WASI_ADVICE_NORMAL => {}
+        _ => return Err(host::__WASI_EINVAL),
+    }
+
+    Ok(())
 }
 
 pub(crate) fn path_create_directory(resolved: PathGet) -> Result<()> {


### PR DESCRIPTION
Windows apparently has no similar syscall available. I've found the following resources:
* [https://libuv.narkive.com/BjsaxmVV/readahead](libuv) doesn't even try to support fadvise on Windows
* [this stackoverflow post](https://stackoverflow.com/questions/1201168/what-is-fadvise-madvise-equivalent-on-windows) mentions only using `ReadFileEx` or passing `FILE_FLAG_SEQUENTIAL_SCAN` to `CreateFile` - both of these calls operate on a different level than a file handle. We could theoretically close the file and reopen it using `CreateFile`, but this looks like a hack.
* [this issue from the Mozilla bugtracker](https://bugzilla.mozilla.org/show_bug.cgi?id=627591) also mentions no counterpart known
* [another Windows library](https://github.com/JFLarvoire/SysToolsLib/blob/8ca0d40c70fa213e53db0b9b59baf885d00f7277/C/MsvcLibX/include/fadvise.h) adding just a dummy no-op `fadvise` implementation