### PR TITLE
Update to syn 1 and quote 1.

### DIFF
--- a/wasi-common-cbindgen/Cargo.toml
+++ b/wasi-common-cbindgen/Cargo.toml
@@ -10,8 +10,8 @@ description = "Interface generator utilities used by wasi-common"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15.34", features = ["full"] }
-quote = "0.6.12"
+syn = { version = "1.0.5", features = ["full"] }
+quote = "1.0.2"
 
 [dev-dependencies]
 trybuild = "1.0.4"


### PR DESCRIPTION
I was doing some experiments with the wasi-common-cbindgen macro and ran into some limitations of the quote macro. Looking into it, I found they were fixed in a newer version. This PR just updates to the newer version.