### PR TITLE
Mark public API functions as unsafe.

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -163,11 +163,11 @@ impl WasiCtx {
             .and_then(|ctx| ctx.build())
     }
 
-    pub(crate) fn contains_fd_entry(&self, fd: host::__wasi_fd_t) -> bool {
+    pub(crate) unsafe fn contains_fd_entry(&self, fd: host::__wasi_fd_t) -> bool {
         self.fds.contains_key(&fd)
     }
 
-    pub(crate) fn get_fd_entry(
+    pub(crate) unsafe fn get_fd_entry(
         &self,
         fd: host::__wasi_fd_t,
         rights_base: host::__wasi_rights_t,
@@ -180,7 +180,7 @@ impl WasiCtx {
         }
     }
 
-    pub(crate) fn get_fd_entry_mut(
+    pub(crate) unsafe fn get_fd_entry_mut(
         &mut self,
         fd: host::__wasi_fd_t,
         rights_base: host::__wasi_rights_t,

--- a/src/hostcalls/fs.rs
+++ b/src/hostcalls/fs.rs
@@ -3,11 +3,11 @@ use crate::ctx::WasiCtx;
 use crate::wasm32;
 
 hostcalls! {
-    pub fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
+    pub unsafe fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
+    pub unsafe fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_pread(
+    pub unsafe fn fd_pread(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
@@ -17,7 +17,7 @@ hostcalls! {
         nread: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_pwrite(
+    pub unsafe fn fd_pwrite(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
@@ -27,7 +27,7 @@ hostcalls! {
         nwritten: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_read(
+    pub unsafe fn fd_read(
         wasi_ctx: &mut WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
@@ -36,13 +36,13 @@ hostcalls! {
         nread: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_renumber(
+    pub unsafe fn fd_renumber(
         wasi_ctx: &mut WasiCtx,
         from: wasm32::__wasi_fd_t,
         to: wasm32::__wasi_fd_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_seek(
+    pub unsafe fn fd_seek(
         wasi_ctx: &mut WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
@@ -51,36 +51,36 @@ hostcalls! {
         newoffset: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_tell(
+    pub unsafe fn fd_tell(
         wasi_ctx: &mut WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
         newoffset: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_fdstat_get(
+    pub unsafe fn fd_fdstat_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
         fdstat_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_fdstat_set_flags(
+    pub unsafe fn fd_fdstat_set_flags(
         wasi_ctx: &WasiCtx,
         fd: wasm32::__wasi_fd_t,
         fdflags: wasm32::__wasi_fdflags_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_fdstat_set_rights(
+    pub unsafe fn fd_fdstat_set_rights(
         wasi_ctx: &mut WasiCtx,
         fd: wasm32::__wasi_fd_t,
         fs_rights_base: wasm32::__wasi_rights_t,
         fs_rights_inheriting: wasm32::__wasi_rights_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_sync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
+    pub unsafe fn fd_sync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t,) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_write(
+    pub unsafe fn fd_write(
         wasi_ctx: &mut WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
@@ -89,7 +89,7 @@ hostcalls! {
         nwritten: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_advise(
+    pub unsafe fn fd_advise(
         wasi_ctx: &WasiCtx,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filesize_t,
@@ -97,14 +97,14 @@ hostcalls! {
         advice: wasm32::__wasi_advice_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_allocate(
+    pub unsafe fn fd_allocate(
         wasi_ctx: &WasiCtx,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filesize_t,
         len: wasm32::__wasi_filesize_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_create_directory(
+    pub unsafe fn path_create_directory(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -112,7 +112,7 @@ hostcalls! {
         path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_link(
+    pub unsafe fn path_link(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         old_dirfd: wasm32::__wasi_fd_t,
@@ -124,7 +124,7 @@ hostcalls! {
         new_path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_open(
+    pub unsafe fn path_open(
         wasi_ctx: &mut WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -138,7 +138,7 @@ hostcalls! {
         fd_out_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_readdir(
+    pub unsafe fn fd_readdir(
         wasi_ctx: &mut WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
@@ -148,7 +148,7 @@ hostcalls! {
         buf_used: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_readlink(
+    pub unsafe fn path_readlink(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -159,7 +159,7 @@ hostcalls! {
         buf_used: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_rename(
+    pub unsafe fn path_rename(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         old_dirfd: wasm32::__wasi_fd_t,
@@ -170,14 +170,14 @@ hostcalls! {
         new_path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_filestat_get(
+    pub unsafe fn fd_filestat_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
         filestat_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_filestat_set_times(
+    pub unsafe fn fd_filestat_set_times(
         wasi_ctx: &WasiCtx,
         fd: wasm32::__wasi_fd_t,
         st_atim: wasm32::__wasi_timestamp_t,
@@ -185,13 +185,13 @@ hostcalls! {
         fst_flags: wasm32::__wasi_fstflags_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_filestat_set_size(
+    pub unsafe fn fd_filestat_set_size(
         wasi_ctx: &WasiCtx,
         fd: wasm32::__wasi_fd_t,
         st_size: wasm32::__wasi_filesize_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_filestat_get(
+    pub unsafe fn path_filestat_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -201,7 +201,7 @@ hostcalls! {
         filestat_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_filestat_set_times(
+    pub unsafe fn path_filestat_set_times(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -213,7 +213,7 @@ hostcalls! {
         fst_flags: wasm32::__wasi_fstflags_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_symlink(
+    pub unsafe fn path_symlink(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         old_path_ptr: wasm32::uintptr_t,
@@ -223,7 +223,7 @@ hostcalls! {
         new_path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_unlink_file(
+    pub unsafe fn path_unlink_file(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -231,7 +231,7 @@ hostcalls! {
         path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn path_remove_directory(
+    pub unsafe fn path_remove_directory(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         dirfd: wasm32::__wasi_fd_t,
@@ -239,14 +239,14 @@ hostcalls! {
         path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_prestat_get(
+    pub unsafe fn fd_prestat_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,
         prestat_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn fd_prestat_dir_name(
+    pub unsafe fn fd_prestat_dir_name(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         fd: wasm32::__wasi_fd_t,

--- a/src/hostcalls/misc.rs
+++ b/src/hostcalls/misc.rs
@@ -7,7 +7,7 @@ use log::trace;
 use wasi_common_cbindgen::wasi_common_cbindgen;
 
 #[wasi_common_cbindgen]
-pub fn proc_exit(rval: wasm32::__wasi_exitcode_t) {
+pub unsafe fn proc_exit(rval: wasm32::__wasi_exitcode_t) {
     trace!("proc_exit(rval={:?})", rval);
     // TODO: Rather than call std::process::exit here, we should trigger a
     // stack unwind similar to a trap.
@@ -15,7 +15,7 @@ pub fn proc_exit(rval: wasm32::__wasi_exitcode_t) {
 }
 
 #[wasi_common_cbindgen]
-pub fn proc_raise(
+pub unsafe fn proc_raise(
     _wasi_ctx: &WasiCtx,
     _memory: &mut [u8],
     _sig: wasm32::__wasi_signal_t,
@@ -24,54 +24,54 @@ pub fn proc_raise(
 }
 
 hostcalls! {
-    pub fn args_get(
+    pub unsafe fn args_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         argv_ptr: wasm32::uintptr_t,
         argv_buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn args_sizes_get(
+    pub unsafe fn args_sizes_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         argc_ptr: wasm32::uintptr_t,
         argv_buf_size_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn environ_get(
+    pub unsafe fn environ_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         environ_ptr: wasm32::uintptr_t,
         environ_buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn environ_sizes_get(
+    pub unsafe fn environ_sizes_get(
         wasi_ctx: &WasiCtx,
         memory: &mut [u8],
         environ_count_ptr: wasm32::uintptr_t,
         environ_size_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn random_get(
+    pub unsafe fn random_get(
         memory: &mut [u8],
         buf_ptr: wasm32::uintptr_t,
         buf_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn clock_res_get(
+    pub unsafe fn clock_res_get(
         memory: &mut [u8],
         clock_id: wasm32::__wasi_clockid_t,
         resolution_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn clock_time_get(
+    pub unsafe fn clock_time_get(
         memory: &mut [u8],
         clock_id: wasm32::__wasi_clockid_t,
         precision: wasm32::__wasi_timestamp_t,
         time_ptr: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn poll_oneoff(
+    pub unsafe fn poll_oneoff(
         memory: &mut [u8],
         input: wasm32::uintptr_t,
         output: wasm32::uintptr_t,
@@ -79,5 +79,5 @@ hostcalls! {
         nevents: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t;
 
-    pub fn sched_yield() -> wasm32::__wasi_errno_t;
+    pub unsafe fn sched_yield() -> wasm32::__wasi_errno_t;
 }

--- a/src/hostcalls/sock.rs
+++ b/src/hostcalls/sock.rs
@@ -6,7 +6,7 @@ use crate::wasm32;
 use wasi_common_cbindgen::wasi_common_cbindgen;
 
 #[wasi_common_cbindgen]
-pub fn sock_recv(
+pub unsafe fn sock_recv(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     sock: wasm32::__wasi_fd_t,
@@ -20,7 +20,7 @@ pub fn sock_recv(
 }
 
 #[wasi_common_cbindgen]
-pub fn sock_send(
+pub unsafe fn sock_send(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     sock: wasm32::__wasi_fd_t,
@@ -33,7 +33,7 @@ pub fn sock_send(
 }
 
 #[wasi_common_cbindgen]
-pub fn sock_shutdown(
+pub unsafe fn sock_shutdown(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     sock: wasm32::__wasi_fd_t,

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -764,7 +764,7 @@ pub(crate) unsafe fn fd_filestat_set_times(
     fd_filestat_set_times_impl(fd, st_atim, st_mtim, fst_flags)
 }
 
-pub(crate) unsafe fn fd_filestat_set_times_impl(
+pub(crate) fn fd_filestat_set_times_impl(
     fd: &File,
     st_atim: wasm32::__wasi_timestamp_t,
     st_mtim: wasm32::__wasi_timestamp_t,

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub(crate) fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
+pub(crate) unsafe fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
     trace!("fd_close(fd={:?})", fd);
 
     let fd = dec_fd(fd);
@@ -30,7 +30,7 @@ pub(crate) fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t) -> Resul
     Ok(())
 }
 
-pub(crate) fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
+pub(crate) unsafe fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
     trace!("fd_datasync(fd={:?})", fd);
 
     let fd = dec_fd(fd);
@@ -41,7 +41,7 @@ pub(crate) fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Result
     fd.sync_data().map_err(Into::into)
 }
 
-pub(crate) fn fd_pread(
+pub(crate) unsafe fn fd_pread(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -80,7 +80,7 @@ pub(crate) fn fd_pread(
             break;
         }
         let vec_len = std::cmp::min(iov.buf_len, left);
-        unsafe { std::slice::from_raw_parts_mut(iov.buf as *mut u8, vec_len) }
+        std::slice::from_raw_parts_mut(iov.buf as *mut u8, vec_len)
             .copy_from_slice(&buf[buf_offset..buf_offset + vec_len]);
         buf_offset += vec_len;
         left -= vec_len;
@@ -91,7 +91,7 @@ pub(crate) fn fd_pread(
     enc_usize_byref(memory, nread, host_nread)
 }
 
-pub(crate) fn fd_pwrite(
+pub(crate) unsafe fn fd_pwrite(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -122,9 +122,10 @@ pub(crate) fn fd_pwrite(
     let buf_size = iovs.iter().map(|v| v.buf_len).sum();
     let mut buf = Vec::with_capacity(buf_size);
     for iov in &iovs {
-        buf.extend_from_slice(unsafe {
-            std::slice::from_raw_parts(iov.buf as *const u8, iov.buf_len)
-        });
+        buf.extend_from_slice(std::slice::from_raw_parts(
+            iov.buf as *const u8,
+            iov.buf_len,
+        ));
     }
     let host_nwritten = hostcalls_impl::fd_pwrite(fd, &buf, offset)?;
 
@@ -133,7 +134,7 @@ pub(crate) fn fd_pwrite(
     enc_usize_byref(memory, nwritten, host_nwritten)
 }
 
-pub(crate) fn fd_read(
+pub(crate) unsafe fn fd_read(
     wasi_ctx: &mut WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -154,7 +155,7 @@ pub(crate) fn fd_read(
     let fe = wasi_ctx.get_fd_entry_mut(fd, host::__WASI_RIGHT_FD_READ, 0)?;
     let mut iovs: Vec<io::IoSliceMut> = iovs
         .iter_mut()
-        .map(|vec| unsafe { host::iovec_to_host_mut(vec) })
+        .map(|vec| host::iovec_to_host_mut(vec))
         .collect();
 
     let maybe_host_nread = match &mut *fe.fd_object.descriptor {
@@ -170,7 +171,7 @@ pub(crate) fn fd_read(
     enc_usize_byref(memory, nread, host_nread)
 }
 
-pub(crate) fn fd_renumber(
+pub(crate) unsafe fn fd_renumber(
     wasi_ctx: &mut WasiCtx,
     from: wasm32::__wasi_fd_t,
     to: wasm32::__wasi_fd_t,
@@ -211,7 +212,7 @@ pub(crate) fn fd_renumber(
     Ok(())
 }
 
-pub(crate) fn fd_seek(
+pub(crate) unsafe fn fd_seek(
     wasi_ctx: &mut WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -253,7 +254,7 @@ pub(crate) fn fd_seek(
     enc_filesize_byref(memory, newoffset, host_newoffset)
 }
 
-pub(crate) fn fd_tell(
+pub(crate) unsafe fn fd_tell(
     wasi_ctx: &mut WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -273,7 +274,7 @@ pub(crate) fn fd_tell(
     enc_filesize_byref(memory, newoffset, host_offset)
 }
 
-pub(crate) fn fd_fdstat_get(
+pub(crate) unsafe fn fd_fdstat_get(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -298,7 +299,7 @@ pub(crate) fn fd_fdstat_get(
     enc_fdstat_byref(memory, fdstat_ptr, fdstat)
 }
 
-pub(crate) fn fd_fdstat_set_flags(
+pub(crate) unsafe fn fd_fdstat_set_flags(
     wasi_ctx: &WasiCtx,
     fd: wasm32::__wasi_fd_t,
     fdflags: wasm32::__wasi_fdflags_t,
@@ -314,7 +315,7 @@ pub(crate) fn fd_fdstat_set_flags(
     hostcalls_impl::fd_fdstat_set_flags(fd, fdflags)
 }
 
-pub(crate) fn fd_fdstat_set_rights(
+pub(crate) unsafe fn fd_fdstat_set_rights(
     wasi_ctx: &mut WasiCtx,
     fd: wasm32::__wasi_fd_t,
     fs_rights_base: wasm32::__wasi_rights_t,
@@ -341,7 +342,7 @@ pub(crate) fn fd_fdstat_set_rights(
     Ok(())
 }
 
-pub(crate) fn fd_sync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
+pub(crate) unsafe fn fd_sync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()> {
     trace!("fd_sync(fd={:?})", fd);
 
     let fd = dec_fd(fd);
@@ -351,7 +352,7 @@ pub(crate) fn fd_sync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Result<()>
     fd.sync_all().map_err(Into::into)
 }
 
-pub(crate) fn fd_write(
+pub(crate) unsafe fn fd_write(
     wasi_ctx: &mut WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -370,10 +371,7 @@ pub(crate) fn fd_write(
     let fd = dec_fd(fd);
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
     let fe = wasi_ctx.get_fd_entry_mut(fd, host::__WASI_RIGHT_FD_WRITE, 0)?;
-    let iovs: Vec<io::IoSlice> = iovs
-        .iter()
-        .map(|vec| unsafe { host::iovec_to_host(vec) })
-        .collect();
+    let iovs: Vec<io::IoSlice> = iovs.iter().map(|vec| host::iovec_to_host(vec)).collect();
 
     // perform unbuffered writes
     let host_nwritten = match &mut *fe.fd_object.descriptor {
@@ -395,7 +393,7 @@ pub(crate) fn fd_write(
     enc_usize_byref(memory, nwritten, host_nwritten)
 }
 
-pub(crate) fn fd_advise(
+pub(crate) unsafe fn fd_advise(
     wasi_ctx: &WasiCtx,
     fd: wasm32::__wasi_fd_t,
     offset: wasm32::__wasi_filesize_t,
@@ -421,7 +419,7 @@ pub(crate) fn fd_advise(
     hostcalls_impl::fd_advise(fd, advice, offset, len)
 }
 
-pub(crate) fn fd_allocate(
+pub(crate) unsafe fn fd_allocate(
     wasi_ctx: &WasiCtx,
     fd: wasm32::__wasi_fd_t,
     offset: wasm32::__wasi_filesize_t,
@@ -452,7 +450,7 @@ pub(crate) fn fd_allocate(
     }
 }
 
-pub(crate) fn path_create_directory(
+pub(crate) unsafe fn path_create_directory(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -480,7 +478,7 @@ pub(crate) fn path_create_directory(
     hostcalls_impl::path_create_directory(resolved)
 }
 
-pub(crate) fn path_link(
+pub(crate) unsafe fn path_link(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     old_dirfd: wasm32::__wasi_fd_t,
@@ -524,7 +522,7 @@ pub(crate) fn path_link(
     hostcalls_impl::path_link(resolved_old, resolved_new)
 }
 
-pub(crate) fn path_open(
+pub(crate) unsafe fn path_open(
     wasi_ctx: &mut WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -594,7 +592,7 @@ pub(crate) fn path_open(
     enc_fd_byref(memory, fd_out_ptr, guest_fd)
 }
 
-pub(crate) fn fd_readdir(
+pub(crate) unsafe fn fd_readdir(
     wasi_ctx: &mut WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -631,7 +629,7 @@ pub(crate) fn fd_readdir(
     enc_usize_byref(memory, buf_used, host_bufused)
 }
 
-pub(crate) fn path_readlink(
+pub(crate) unsafe fn path_readlink(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -673,7 +671,7 @@ pub(crate) fn path_readlink(
     enc_usize_byref(memory, buf_used, host_bufused)
 }
 
-pub(crate) fn path_rename(
+pub(crate) unsafe fn path_rename(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     old_dirfd: wasm32::__wasi_fd_t,
@@ -715,7 +713,7 @@ pub(crate) fn path_rename(
     hostcalls_impl::path_rename(resolved_old, resolved_new)
 }
 
-pub(crate) fn fd_filestat_get(
+pub(crate) unsafe fn fd_filestat_get(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -739,7 +737,7 @@ pub(crate) fn fd_filestat_get(
     enc_filestat_byref(memory, filestat_ptr, host_filestat)
 }
 
-pub(crate) fn fd_filestat_set_times(
+pub(crate) unsafe fn fd_filestat_set_times(
     wasi_ctx: &WasiCtx,
     fd: wasm32::__wasi_fd_t,
     st_atim: wasm32::__wasi_timestamp_t,
@@ -766,7 +764,7 @@ pub(crate) fn fd_filestat_set_times(
     fd_filestat_set_times_impl(fd, st_atim, st_mtim, fst_flags)
 }
 
-pub(crate) fn fd_filestat_set_times_impl(
+pub(crate) unsafe fn fd_filestat_set_times_impl(
     fd: &File,
     st_atim: wasm32::__wasi_timestamp_t,
     st_mtim: wasm32::__wasi_timestamp_t,
@@ -802,7 +800,7 @@ pub(crate) fn fd_filestat_set_times_impl(
     set_file_handle_times(fd, atim, mtim).map_err(Into::into)
 }
 
-pub(crate) fn fd_filestat_set_size(
+pub(crate) unsafe fn fd_filestat_set_size(
     wasi_ctx: &WasiCtx,
     fd: wasm32::__wasi_fd_t,
     st_size: wasm32::__wasi_filesize_t,
@@ -822,7 +820,7 @@ pub(crate) fn fd_filestat_set_size(
     fd.set_len(st_size).map_err(Into::into)
 }
 
-pub(crate) fn path_filestat_get(
+pub(crate) unsafe fn path_filestat_get(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -857,7 +855,7 @@ pub(crate) fn path_filestat_get(
     enc_filestat_byref(memory, filestat_ptr, host_filestat)
 }
 
-pub(crate) fn path_filestat_set_times(
+pub(crate) unsafe fn path_filestat_set_times(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -896,7 +894,7 @@ pub(crate) fn path_filestat_set_times(
     hostcalls_impl::path_filestat_set_times(resolved, dirflags, st_atim, st_mtim, fst_flags)
 }
 
-pub(crate) fn path_symlink(
+pub(crate) unsafe fn path_symlink(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     old_path_ptr: wasm32::uintptr_t,
@@ -931,7 +929,7 @@ pub(crate) fn path_symlink(
     hostcalls_impl::path_symlink(old_path, resolved_new)
 }
 
-pub(crate) fn path_unlink_file(
+pub(crate) unsafe fn path_unlink_file(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -958,7 +956,7 @@ pub(crate) fn path_unlink_file(
     hostcalls_impl::path_unlink_file(resolved)
 }
 
-pub(crate) fn path_remove_directory(
+pub(crate) unsafe fn path_remove_directory(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     dirfd: wasm32::__wasi_fd_t,
@@ -985,7 +983,7 @@ pub(crate) fn path_remove_directory(
     hostcalls_impl::path_remove_directory(resolved)
 }
 
-pub(crate) fn fd_prestat_get(
+pub(crate) unsafe fn fd_prestat_get(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,
@@ -1024,7 +1022,7 @@ pub(crate) fn fd_prestat_get(
         })
 }
 
-pub(crate) fn fd_prestat_dir_name(
+pub(crate) unsafe fn fd_prestat_dir_name(
     wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     fd: wasm32::__wasi_fd_t,

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -581,7 +581,7 @@ pub(crate) unsafe fn path_open(
     let fd = hostcalls_impl::path_open(resolved, read, write, oflags, fs_flags)?;
 
     // Determine the type of the new file descriptor and which rights contradict with this type
-    let (_ty, max_base, max_inheriting) = unsafe { determine_type_rights(&fd) }?;
+    let (_ty, max_base, max_inheriting) = determine_type_rights(&fd)?;
     let mut fe = FdEntry::from(fd)?;
     fe.rights_base &= max_base;
     fe.rights_inheriting &= max_inheriting;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 macro_rules! hostcalls {
-    ($(pub fn $name:ident($($arg:ident: $ty:ty,)*) -> $ret:ty;)*) => ($(
+    ($(pub unsafe fn $name:ident($($arg:ident: $ty:ty,)*) -> $ret:ty;)*) => ($(
             #[wasi_common_cbindgen::wasi_common_cbindgen]
-            pub fn $name($($arg: $ty,)*) -> $ret {
+            pub unsafe fn $name($($arg: $ty,)*) -> $ret {
                 let ret = match crate::hostcalls_impl::$name($($arg,)*) {
                     Ok(()) => crate::host::__WASI_ESUCCESS,
                     Err(e) => e.as_wasi_errno(),


### PR DESCRIPTION
This marks the public hostcalls functions as unsafe.

This is generalizing from Rust's `from_raw_fd` function, which is
unsafe. The observation is that nothing prevents code using this
function from passing a bogus or stale dangling file descriptor and
corrupting an arbitrary open stream.

Technically, some of these functions don't use file descriptors, such as
random, clocks, and a few others. However I expect that in the future,
random and clocks will switch to using file descriptors anyway, and it
keeps the macro definitions simpler if we only have to handle one form.

This is a complex topic, so I'm not in a hurry here. I want to figure out
what the right thing to do is.