### PR TITLE
Refactor mgmt of misc testsuite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ cranelift-wasm = "0.40.0"
 cranelift-native = "0.40.0"
 target-lexicon = "0.4.0"
 pretty_env_logger = "0.3.0"
+tempfile = "3.1.0"
 
 [patch."https://github.com/CraneStation/wasi-common"]
 wasi-common = { path = "." }

--- a/build.rs
+++ b/build.rs
@@ -113,7 +113,7 @@ fn write_testsuite_tests(out: &mut File, dir_entry: DirEntry, testsuite: &str) -
         "    fn {}() -> Result<(), String> {{",
         avoid_keywords(&stemstr.replace("-", "_"))
     )?;
-    write!(out, "        setup_log();")?;
+    writeln!(out, "        setup_log();")?;
     write!(out, "        let path = std::path::Path::new(\"")?;
     // Write out the string with escape_debug to prevent special characters such
     // as backslash from being reinterpreted.
@@ -129,7 +129,11 @@ fn write_testsuite_tests(out: &mut File, dir_entry: DirEntry, testsuite: &str) -
     let workspace = if no_preopens(testsuite, stemstr) {
         "None"
     } else {
-        "Some(&utils::prepare_workspace(&bin_name)?)"
+        writeln!(
+            out,
+            "        let workspace = utils::prepare_workspace(&bin_name)?;"
+        )?;
+        "Some(workspace.path())"
     };
     writeln!(
         out,


### PR DESCRIPTION
Changes:
* use [tempfile] crate for auto mgmt of temp dirs
* use concrete types in place of generics in `utils` module

[tempfile]: https://github.com/Stebalien/tempfile