### PR TITLE
Fix path_remove_directory on *nixes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -165,7 +165,6 @@ cfg_if::cfg_if! {
                 match name {
                     "path_rename_trailing_slashes" => true,
                     "path_symlink_trailing_slashes" => true,
-                    "remove_directory_trailing_slashes" => true,
                     _ => false,
                 }
             } else {

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -978,7 +978,9 @@ pub(crate) unsafe fn path_remove_directory(
     let dirfd = wasi_ctx
         .get_fd_entry(dirfd, host::__WASI_RIGHT_PATH_REMOVE_DIRECTORY, 0)
         .and_then(|fe| fe.fd_object.descriptor.as_file())?;
-    let resolved = path_get(dirfd, 0, path, false)?;
+    let resolved = path_get(dirfd, 0, path, true)?;
+
+    log::debug!("path_remove_directory resolved={:?}", resolved);
 
     hostcalls_impl::path_remove_directory(resolved)
 }

--- a/src/hostcalls_impl/fs_helpers.rs
+++ b/src/hostcalls_impl/fs_helpers.rs
@@ -5,6 +5,7 @@ use crate::{host, Error, Result};
 use std::fs::File;
 use std::path::{Component, Path};
 
+#[derive(Debug)]
 pub(crate) struct PathGet {
     dirfd: File,
     path: String,


### PR DESCRIPTION
This PR fixes `path_remove_directory` on *nix hosts which includes Linux and macOS. Windows, however, still needs more work in order to make `remove_directory_trailing_slashes` pass.