### PR TITLE
Fix path_rename on *nix hosts

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -163,7 +163,6 @@ cfg_if::cfg_if! {
         fn ignore(testsuite: &str, name: &str) -> bool {
             if testsuite == "misc_testsuite" {
                 match name {
-                    "path_rename_trailing_slashes" => true,
                     "path_symlink_trailing_slashes" => true,
                     _ => false,
                 }

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -707,8 +707,11 @@ pub(crate) unsafe fn path_rename(
     let new_dirfd = wasi_ctx
         .get_fd_entry(new_dirfd, host::__WASI_RIGHT_PATH_RENAME_TARGET, 0)
         .and_then(|fe| fe.fd_object.descriptor.as_file())?;
-    let resolved_old = path_get(old_dirfd, 0, old_path, false)?;
-    let resolved_new = path_get(new_dirfd, 0, new_path, false)?;
+    let resolved_old = path_get(old_dirfd, 0, old_path, true)?;
+    let resolved_new = path_get(new_dirfd, 0, new_path, true)?;
+
+    log::debug!("path_rename resolved_old={:?}", resolved_old);
+    log::debug!("path_rename resolved_new={:?}", resolved_new);
 
     hostcalls_impl::path_rename(resolved_old, resolved_new)
 }

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -207,26 +207,6 @@ pub(crate) fn path_readlink(resolved: PathGet, buf: &mut [u8]) -> Result<usize> 
     }
 }
 
-pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> Result<()> {
-    use nix::libc::renameat;
-    let old_path_cstr = CString::new(resolved_old.path().as_bytes()).map_err(|_| Error::EILSEQ)?;
-    let new_path_cstr = CString::new(resolved_new.path().as_bytes()).map_err(|_| Error::EILSEQ)?;
-
-    let res = unsafe {
-        renameat(
-            resolved_old.dirfd().as_raw_fd(),
-            old_path_cstr.as_ptr(),
-            resolved_new.dirfd().as_raw_fd(),
-            new_path_cstr.as_ptr(),
-        )
-    };
-    if res != 0 {
-        Err(host_impl::errno_from_nix(nix::errno::Errno::last()))
-    } else {
-        Ok(())
-    }
-}
-
 pub(crate) fn fd_filestat_get_impl(file: &std::fs::File) -> Result<host::__wasi_filestat_t> {
     use std::os::unix::fs::MetadataExt;
 


### PR DESCRIPTION
The fix contains an errno remapping in macOS case where in case when we try to rename a file into a path with a trailing slash an `ENOENT` is returned. In this case, if the destination does not exist, an `ENOTDIR` should be thrown as is thrown correctly on Linux hosts. Thus, as a fix, if an `ENOENT` is thrown, an additional check is performed to see whether the destination path indeed contains a trailing slash, and if so, the errno is adjusted to `ENOTDIR` to match the POSIX/WASI spec.

Alas, Windows requires more investigation in order to provide a fix, so it's currently skipped.

This PR builds on #102 hence it is expected for the former to be merged first before we merge this PR.