### PR TITLE
Use cvt from the cvt crate in winx

### DIFF
--- a/winx/Cargo.toml
+++ b/winx/Cargo.toml
@@ -9,3 +9,4 @@ description = "Windows API helper library"
 [dependencies]
 winapi = { version = "0.3", features = ["std", "errhandlingapi", "handleapi", "processthreadsapi", "securitybaseapi", "winbase", "winerror", "ws2def", "fileapi", "aclapi" ] }
 bitflags = "1.0"
+cvt = "0.1"

--- a/winx/src/file.rs
+++ b/winx/src/file.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 use crate::{winerror, Result};
+use cvt::cvt;
 use std::ffi::{c_void, OsString};
 use std::fs::File;
 use std::io;
@@ -378,15 +379,6 @@ pub fn get_file_path(file: &File) -> Result<OsString> {
         .ok_or(winerror::WinError::ERROR_BUFFER_OVERFLOW)?;
 
     Ok(OsString::from_wide(written_bytes))
-}
-
-// Taken from Rust libstd, file libstd/sys/windows/fs.rs
-fn cvt(i: winapi::shared::minwindef::BOOL) -> io::Result<()> {
-    if i == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
 }
 
 pub fn get_fileinfo(file: &File) -> io::Result<fileapi::BY_HANDLE_FILE_INFORMATION> {


### PR DESCRIPTION
`cvt` was copied over from Rust libstd in https://github.com/CraneStation/wasi-common/pull/42, but I've created a separate crate for it, so as to be able to reuse it across crates.