### PR TITLE
moved preopen_path field out of FdEntry

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -115,7 +115,7 @@ impl WasiCtxBuilder {
                 preopen_fd = preopen_fd.checked_add(1).ok_or(Error::ENFILE)?;
             }
             let mut fe = FdEntry::from(dir)?;
-            fe.preopen_path = Some(guest_path);
+            fe.fd_object.descriptor.as_file_details_mut()?.preopen_path = Some(guest_path);
             self.fds.insert(preopen_fd, fe);
             preopen_fd += 1;
         }

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -19,7 +19,13 @@ pub(crate) unsafe fn fd_close(wasi_ctx: &mut WasiCtx, fd: wasm32::__wasi_fd_t) -
     let fd = dec_fd(fd);
     if let Some(fdent) = wasi_ctx.fds.get(&fd) {
         // can't close preopened files
-        if fdent.fd_object.descriptor.as_file_details()?.preopen_path.is_some() {
+        if fdent
+            .fd_object
+            .descriptor
+            .as_file_details()?
+            .preopen_path
+            .is_some()
+        {
             return Err(Error::ENOTSUP);
         }
     }
@@ -188,8 +194,19 @@ pub(crate) unsafe fn fd_renumber(
     // Don't allow renumbering over a pre-opened resource.
     // TODO: Eventually, we do want to permit this, once libpreopen in
     // userspace is capable of removing entries from its tables as well.
-    if wasi_ctx.fds[&from].fd_object.descriptor.as_file_details()?.preopen_path.is_some()
-        || wasi_ctx.fds[&to].fd_object.descriptor.as_file_details()?.preopen_path.is_some() {
+    if wasi_ctx.fds[&from]
+        .fd_object
+        .descriptor
+        .as_file_details()?
+        .preopen_path
+        .is_some()
+        || wasi_ctx.fds[&to]
+            .fd_object
+            .descriptor
+            .as_file_details()?
+            .preopen_path
+            .is_some()
+    {
         return Err(Error::ENOTSUP);
     }
 
@@ -1006,7 +1023,13 @@ pub(crate) unsafe fn fd_prestat_get(
     wasi_ctx
         .get_fd_entry(fd, host::__WASI_RIGHT_PATH_OPEN, 0)
         .and_then(|fe| {
-            let po_path = fe.fd_object.descriptor.as_file_details()?.preopen_path.as_ref().ok_or(Error::ENOTSUP)?;
+            let po_path = fe
+                .fd_object
+                .descriptor
+                .as_file_details()?
+                .preopen_path
+                .as_ref()
+                .ok_or(Error::ENOTSUP)?;
             if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
                 return Err(Error::ENOTDIR);
             }
@@ -1047,7 +1070,13 @@ pub(crate) unsafe fn fd_prestat_dir_name(
     wasi_ctx
         .get_fd_entry(fd, host::__WASI_RIGHT_PATH_OPEN, 0)
         .and_then(|fe| {
-            let po_path = fe.fd_object.descriptor.as_file_details()?.preopen_path.as_ref().ok_or(Error::ENOTSUP)?;
+            let po_path = fe
+                .fd_object
+                .descriptor
+                .as_file_details()?
+                .preopen_path
+                .as_ref()
+                .ok_or(Error::ENOTSUP)?;
             if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
                 return Err(Error::ENOTDIR);
             }

--- a/src/sys/unix/fdentry_impl.rs
+++ b/src/sys/unix/fdentry_impl.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
 impl AsRawFd for Descriptor {
     fn as_raw_fd(&self) -> RawFd {
         match self {
-            Self::OsFile(file) => file.as_raw_fd(),
+            Self::OsFile(details) => details.file.as_raw_fd(),
             Self::Stdin => io::stdin().as_raw_fd(),
             Self::Stdout => io::stdout().as_raw_fd(),
             Self::Stderr => io::stderr().as_raw_fd(),

--- a/src/sys/windows/fdentry_impl.rs
+++ b/src/sys/windows/fdentry_impl.rs
@@ -37,7 +37,7 @@ impl DerefMut for OsFile {
 impl AsRawHandle for Descriptor {
     fn as_raw_handle(&self) -> RawHandle {
         match self {
-            Self::OsFile(file) => file.as_raw_handle(),
+            Self::OsFile(details) => details.file.as_raw_handle(),
             Self::Stdin => io::stdin().as_raw_handle(),
             Self::Stdout => io::stdout().as_raw_handle(),
             Self::Stderr => io::stderr().as_raw_handle(),


### PR DESCRIPTION
This PR introduces a new struct
```rust
struct FileDetails {
    file: OsFile,
    preopen_path: Option<PathBuf>,
}
```
Motivation: as `preopen_path` doesn't make sense with Stdin, Stdout, Stderr, and in the future with Socket file descriptors, I suggest moving it inside a `Descriptor::OsFile` enum variant.

Drawbacks: 
increased verbosity in some cases:
```
-fe.preopen_path = Some(guest_path);
+fe.fd_object.descriptor.as_file_details_mut()?.preopen_path = Some(guest_path);
```

I'd like to hear any feedback about this change.

P.S.
Thanks @sunfishcode for your mentorship!