### PR TITLE
Try to somehow implement clock_res_get on Windows. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ cranelift-codegen = "0.46.1"
 target-lexicon = "0.8.1"
 pretty_env_logger = "0.3.0"
 tempfile = "3.1.0"
+# this is just a temp fix to make the tests build and run; I hope this to be
+# completely removed when we merge `wasi-common` into `wasmtime`
+faerie = "=0.11.0"
 
 [patch."https://github.com/CraneStation/wasi-common"]
 wasi-common = { path = "." }

--- a/src/sys/windows/hostcalls_impl/misc.rs
+++ b/src/sys/windows/hostcalls_impl/misc.rs
@@ -52,7 +52,7 @@ pub(crate) fn clock_res_get(clock_id: wasi::__wasi_clockid_t) -> Result<wasi::__
         // [4] https://www.codeproject.com/Tips/1011902/High-Resolution-Time-For-Windows
         // [5] https://stackoverflow.com/questions/7685762/windows-7-timing-functions-how-to-use-getsystemtimeadjustment-correctly
         // [6] https://bugs.python.org/issue19007
-        wasi::__WASI_CLOCK_REALTIME => 55000,
+        wasi::__WASI_CLOCK_REALTIME => 55_000_000,
         // std::time::Instant uses QueryPerformanceCounter & QueryPerformanceFrequency internally
         wasi::__WASI_CLOCK_MONOTONIC => get_perf_counter_resolution()?.as_nanos().try_into()?,
         // The best we can do is to hardcode the value from the docs.

--- a/src/sys/windows/hostcalls_impl/misc.rs
+++ b/src/sys/windows/hostcalls_impl/misc.rs
@@ -5,6 +5,7 @@ use crate::helpers::systemtime_to_timestamp;
 use crate::hostcalls_impl::{ClockEventData, FdEventData};
 use crate::memory::*;
 use crate::sys::host_impl;
+use crate::sys::host_impl;
 use crate::{wasi, wasi32, Error, Result};
 use cpu_time::{ProcessTime, ThreadTime};
 use lazy_static::lazy_static;

--- a/winx/src/lib.rs
+++ b/winx/src/lib.rs
@@ -25,6 +25,7 @@
 extern crate bitflags;
 
 pub mod file;
+pub mod time;
 pub mod winerror;
 
 use winerror::WinError;

--- a/winx/src/time.rs
+++ b/winx/src/time.rs
@@ -1,0 +1,10 @@
+use cvt::cvt;
+use winapi::um::{profileapi::QueryPerformanceFrequency, winnt::LARGE_INTEGER};
+
+pub fn perf_counter_frequency() -> std::io::Result<u64> {
+    unsafe {
+        let mut frequency: LARGE_INTEGER = std::mem::zeroed();
+        cvt(QueryPerformanceFrequency(&mut frequency))?;
+        Ok(*frequency.QuadPart() as u64)
+    }
+}


### PR DESCRIPTION
I don't like this implementation, and I'm not sure if we should merge it, but I think it's the best we can do without overly complicating stuff. We depend on the implementation details on `std::time::{SystemTime, Instant}` and `cpu-time` (on the underlying Windows syscalls).

While we could avoid it for `ProcessTime` and `ThreadTime` by adding an associated function returning the timer resolution, possibly the same for `Instant` (and wait forever until it's stable), but the problems for `SystemTime` are much more fundamental. We may have to reconsider this part of WASI API.

Depends on #117 and the implementation details of #119.