### PR TITLE
Fixes CraneStation/wasmtime#396

### DIFF
--- a/src/sys/unix/bsd/mod.rs
+++ b/src/sys/unix/bsd/mod.rs
@@ -1,2 +1,19 @@
 pub(crate) mod hostcalls_impl;
 pub(crate) mod osfile;
+
+pub(crate) mod fdentry_impl {
+    use crate::{sys::host_impl, Result};
+    use std::os::unix::prelude::AsRawFd;
+
+    pub(crate) unsafe fn isatty(fd: &impl AsRawFd) -> Result<bool> {
+        let res = libc::isatty(fd.as_raw_fd());
+        if res == 0 {
+            Ok(true)
+        } else {
+            match nix::errno::Errno::last() {
+                nix::errno::Errno::ENOTTY => Ok(false),
+                x => Err(host_impl::errno_from_nix(x)),
+            }
+        }
+    }
+}

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -120,6 +120,10 @@ pub(crate) fn path_open(
     // Call openat. Use mode 0o666 so that we follow whatever the user's
     // umask is, but don't set the executable flag, because it isn't yet
     // meaningful for WASI programs to create executable files.
+
+    log::debug!("path_open resolved = {:?}", resolved);
+    log::debug!("path_open oflags = {:?}", nix_all_oflags);
+
     let new_fd = match openat(
         resolved.dirfd().as_raw_fd(),
         resolved.path(),
@@ -171,6 +175,8 @@ pub(crate) fn path_open(
             }
         }
     };
+
+    log::debug!("path_open new_fd = {:?}", new_fd);
 
     // Determine the type of the new file descriptor and which rights contradict with this type
     Ok(unsafe { File::from_raw_fd(new_fd) })

--- a/src/sys/unix/linux/mod.rs
+++ b/src/sys/unix/linux/mod.rs
@@ -1,2 +1,26 @@
 pub(crate) mod hostcalls_impl;
 pub(crate) mod osfile;
+
+pub(crate) mod fdentry_impl {
+    use crate::{sys::host_impl, Result};
+    use std::os::unix::prelude::AsRawFd;
+
+    pub(crate) unsafe fn isatty(fd: &impl AsRawFd) -> Result<bool> {
+        use nix::errno::Errno;
+
+        let res = libc::isatty(fd.as_raw_fd());
+        if res == 0 {
+            Ok(true)
+        } else {
+            match Errno::last() {
+                // While POSIX specifies ENOTTY if the passed
+                // fd is *not* a tty, on Linux, some implementations
+                // may return EINVAL instead.
+                //
+                // https://linux.die.net/man/3/isatty
+                Errno::ENOTTY | Errno::EINVAL => Ok(false),
+                x => Err(host_impl::errno_from_nix(x)),
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit fixes an issue with incorrect handling of /dev/(u)random
on Linux. It turns out that `nix::unistd::isatty` call handled only
the POSIX spec case where `ENOTTY` is returned in case the passed
in file descriptor is OK but not a TTY, whereas on Linux this is not
always the case. On Linux, it can be the case that `EINVAL` is returned
instead and this case AFAIK is not handled by the `nix` crate. This
commit fixes this by using `libc::isatty` syscall directly and checking
the return values.