### PR TITLE
Fix `remove_directory_trailing_slashes` on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -186,7 +186,6 @@ mod wasm_tests {
                         "fd_readdir" => true,
                         "path_rename_trailing_slashes" => true,
                         "path_symlink_trailing_slashes" => true,
-                        "remove_directory_trailing_slashes" => true,
                         _ => false,
                     }
                 } else {

--- a/src/sys/windows/host_impl.rs
+++ b/src/sys/windows/host_impl.rs
@@ -2,7 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(unused)]
-use crate::{host, Result, Error};
+use crate::{host, Error, Result};
 use std::ffi::OsStr;
 use std::fs::OpenOptions;
 use std::os::windows::ffi::OsStrExt;
@@ -34,6 +34,7 @@ pub(crate) fn errno_from_win(error: winx::winerror::WinError) -> host::__wasi_er
         ERROR_BUFFER_OVERFLOW => host::__WASI_ENAMETOOLONG,
         ERROR_NOT_A_REPARSE_POINT => host::__WASI_EINVAL,
         ERROR_NEGATIVE_SEEK => host::__WASI_EINVAL,
+        ERROR_DIRECTORY => host::__WASI_ENOTDIR,
         _ => host::__WASI_ENOTSUP,
     }
 }

--- a/winx/src/winerror.rs
+++ b/winx/src/winerror.rs
@@ -84,6 +84,8 @@ win_error_expand! {
     ERROR_NOT_A_REPARSE_POINT,
     /// An attempt was made to move the file pointer before the beginning of the file.
     ERROR_NEGATIVE_SEEK,
+    /// The directory name is invalid.
+    ERROR_DIRECTORY,
 }
 
 impl WinError {


### PR DESCRIPTION
This commit provides a fix for `remove_directory_trailing_slashes`
test case on Windows. It adds a missing mapping between the following
WinAPI error code and WASI error:

```
ERROR_DIRECTORY => __WASI_ENOTDIR
```

where `ERROR_DIRECTORY` is thrown when the directory name is invalid.