### PR TITLE
Refactor poll_oneoff on *nix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -199,6 +199,7 @@ mod wasm_tests {
                         "truncation_rights" => true,
                         "fd_readdir" => true,
                         "path_rename_trailing_slashes" => true,
+                        "poll_oneoff" => true,
                         _ => false,
                     }
                 } else {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -134,7 +134,9 @@ impl WasiCtxBuilder {
             }
             let mut fe = FdEntry::from(dir)?;
             fe.preopen_path = Some(guest_path);
+            log::debug!("WasiCtx inserting ({:?}, {:?})", preopen_fd, fe);
             self.fds.insert(preopen_fd, fe);
+            log::debug!("WasiCtx fds = {:?}", self.fds);
             preopen_fd = preopen_fd.checked_add(1).ok_or(Error::ENFILE)?;
         }
 

--- a/src/hostcalls_impl/misc.rs
+++ b/src/hostcalls_impl/misc.rs
@@ -183,7 +183,7 @@ pub(crate) fn clock_time_get(
 }
 
 pub(crate) fn poll_oneoff(
-    _wasi_ctx: &WasiCtx,
+    wasi_ctx: &WasiCtx,
     memory: &mut [u8],
     input: wasm32::uintptr_t,
     output: wasm32::uintptr_t,
@@ -207,7 +207,7 @@ pub(crate) fn poll_oneoff(
     let input_slice = dec_slice_of::<wasm32::__wasi_subscription_t>(memory, input, nsubscriptions)?;
     let input: Vec<_> = input_slice.iter().map(dec_subscription).collect();
     let output_slice = dec_slice_of_mut::<wasm32::__wasi_event_t>(memory, output, nsubscriptions)?;
-    let events_count = hostcalls_impl::poll_oneoff(input, output_slice)?;
+    let events_count = hostcalls_impl::poll_oneoff(wasi_ctx, input, output_slice)?;
 
     trace!("     | *nevents={:?}", events_count);
 

--- a/src/hostcalls_impl/misc.rs
+++ b/src/hostcalls_impl/misc.rs
@@ -205,11 +205,8 @@ pub(crate) fn poll_oneoff(
     enc_pointee(memory, nevents, 0)?;
 
     let input_slice = dec_slice_of::<wasm32::__wasi_subscription_t>(memory, input, nsubscriptions)?;
-    let input: Vec<_> = input_slice
-        .iter()
-        .map(dec_subscription)
-        .collect::<Result<Vec<_>>>()?;
-    let events = hostcalls_impl::poll_oneoff(wasi_ctx, input)?;
+
+    let events = hostcalls_impl::poll_oneoff(wasi_ctx, input_slice.iter().map(dec_subscription))?;
 
     let output_slice = dec_slice_of_mut::<wasm32::__wasi_event_t>(memory, output, nsubscriptions)?;
     let mut events_count = 0;

--- a/src/hostcalls_impl/misc.rs
+++ b/src/hostcalls_impl/misc.rs
@@ -222,10 +222,10 @@ pub(crate) fn poll_oneoff(
         match event.type_ {
             host::__WASI_EVENTTYPE_CLOCK => {
                 let clock = unsafe { event.u.clock };
-                let delay = wasi_clock_to_relative_ns_delay(clock)? / 1_000_000; // in milliseconds!
+                let delay = wasi_clock_to_relative_ns_delay(clock)?;
 
                 log::debug!("poll_oneoff event.u.clock = {:?}", clock);
-                log::debug!("poll_oneoff delay = {:?}ms", delay);
+                log::debug!("poll_oneoff delay = {:?}ns", delay);
 
                 let current_event = ClockEventData {
                     delay,
@@ -299,7 +299,7 @@ fn wasi_clock_to_relative_ns_delay(
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct ClockEventData {
-    pub(crate) delay: u128,
+    pub(crate) delay: u128, // delay is expressed in nanoseconds
     pub(crate) userdata: host::__wasi_userdata_t,
 }
 

--- a/src/sys/unix/fdentry_impl.rs
+++ b/src/sys/unix/fdentry_impl.rs
@@ -67,14 +67,14 @@ pub(crate) unsafe fn determine_type_rights<Fd: AsRawFd>(
         let file = std::mem::ManuallyDrop::new(std::fs::File::from_raw_fd(fd.as_raw_fd()));
         let ft = file.metadata()?.file_type();
         if ft.is_block_device() {
-            log::debug!("Fd {:?} is a block device", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is a block device", fd.as_raw_fd());
             (
                 host::__WASI_FILETYPE_BLOCK_DEVICE,
                 host::RIGHTS_BLOCK_DEVICE_BASE,
                 host::RIGHTS_BLOCK_DEVICE_INHERITING,
             )
         } else if ft.is_char_device() {
-            log::debug!("Fd {:?} is a char device", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is a char device", fd.as_raw_fd());
             if isatty(fd)? {
                 (
                     host::__WASI_FILETYPE_CHARACTER_DEVICE,
@@ -89,21 +89,21 @@ pub(crate) unsafe fn determine_type_rights<Fd: AsRawFd>(
                 )
             }
         } else if ft.is_dir() {
-            log::debug!("Fd {:?} is a directory", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is a directory", fd.as_raw_fd());
             (
                 host::__WASI_FILETYPE_DIRECTORY,
                 host::RIGHTS_DIRECTORY_BASE,
                 host::RIGHTS_DIRECTORY_INHERITING,
             )
         } else if ft.is_file() {
-            log::debug!("Fd {:?} is a file", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is a file", fd.as_raw_fd());
             (
                 host::__WASI_FILETYPE_REGULAR_FILE,
                 host::RIGHTS_REGULAR_FILE_BASE,
                 host::RIGHTS_REGULAR_FILE_INHERITING,
             )
         } else if ft.is_socket() {
-            log::debug!("Fd {:?} is a socket", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is a socket", fd.as_raw_fd());
             use nix::sys::socket;
             match socket::getsockopt(fd.as_raw_fd(), socket::sockopt::SockType)? {
                 socket::SockType::Datagram => (
@@ -119,14 +119,14 @@ pub(crate) unsafe fn determine_type_rights<Fd: AsRawFd>(
                 _ => return Err(Error::EINVAL),
             }
         } else if ft.is_fifo() {
-            log::debug!("Fd {:?} is a fifo", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is a fifo", fd.as_raw_fd());
             (
                 host::__WASI_FILETYPE_UNKNOWN,
                 host::RIGHTS_REGULAR_FILE_BASE,
                 host::RIGHTS_REGULAR_FILE_INHERITING,
             )
         } else {
-            log::debug!("Fd {:?} is unknown", fd.as_raw_fd());
+            log::debug!("Host fd {:?} is unknown", fd.as_raw_fd());
             return Err(Error::EINVAL);
         }
     };

--- a/src/sys/unix/hostcalls_impl/fs.rs
+++ b/src/sys/unix/hostcalls_impl/fs.rs
@@ -175,7 +175,7 @@ pub(crate) fn path_open(
         }
     };
 
-    log::debug!("path_open new_fd = {:?}", new_fd);
+    log::debug!("path_open (host) new_fd = {:?}", new_fd);
 
     // Determine the type of the new file descriptor and which rights contradict with this type
     Ok(unsafe { File::from_raw_fd(new_fd) })

--- a/src/sys/unix/hostcalls_impl/misc.rs
+++ b/src/sys/unix/hostcalls_impl/misc.rs
@@ -1,8 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_unsafe)]
-use crate::memory::*;
 use crate::sys::host_impl;
-use crate::{ctx::WasiCtx, host, wasm32, Error, Result};
+use crate::{ctx::WasiCtx, host, Error, Result};
 use nix::libc::{self, c_int};
 use std::cmp;
 use std::mem::MaybeUninit;
@@ -71,33 +70,42 @@ pub(crate) fn clock_time_get(clock_id: host::__wasi_clockid_t) -> Result<host::_
 
 pub(crate) fn poll_oneoff(
     wasi_ctx: &WasiCtx,
-    input: Vec<Result<host::__wasi_subscription_t>>,
-    output_slice: &mut [wasm32::__wasi_event_t],
-) -> Result<wasm32::size_t> {
-    use std::os::unix::prelude::*;
+    input: Vec<host::__wasi_subscription_t>,
+) -> Result<Vec<host::__wasi_event_t>> {
+    use nix::{
+        errno::Errno,
+        poll::{poll, PollFd, PollFlags},
+    };
+    use std::os::unix::prelude::AsRawFd;
 
-    let timeout = input
-        .iter()
-        .filter_map(|event| match event {
-            Ok(event) if event.type_ == wasm32::__WASI_EVENTTYPE_CLOCK => Some(ClockEventData {
-                delay: wasi_clock_to_relative_ns_delay(unsafe { event.u.clock }).ok()? / 1_000_000,
-                userdata: event.userdata,
-            }),
-            _ => None,
-        })
-        .min_by_key(|event| event.delay);
-
+    let mut timeout: Option<ClockEventData> = None;
     let mut fd_events = Vec::new();
-    for event in &input {
-        if let Ok(event) = event {
-            if event.type_ == wasm32::__WASI_EVENTTYPE_FD_READ
-                || event.type_ == wasm32::__WASI_EVENTTYPE_FD_WRITE
-            {
+    for event in input {
+        match event.type_ {
+            host::__WASI_EVENTTYPE_CLOCK => {
+                let clock = unsafe { event.u.clock };
+                log::debug!("poll_oneoff event.u.clock = {:?}", clock);
+                let delay = wasi_clock_to_relative_ns_delay(clock)? / 1_000_000; // in milliseconds!
+                log::debug!("poll_oneoff delay = {:?}ms", delay);
+                let current_event = ClockEventData {
+                    delay,
+                    userdata: event.userdata,
+                };
+                if let Some(ref mut timeout) = timeout {
+                    if current_event.delay < timeout.delay {
+                        *timeout = current_event;
+                    }
+                } else {
+                    timeout = Some(current_event);
+                }
+            }
+            host::__WASI_EVENTTYPE_FD_READ => {
                 let wasi_fd = unsafe { event.u.fd_readwrite.fd };
                 let fd = unsafe {
                     wasi_ctx
-                        .get_fd_entry(wasi_fd, host::__WASI_RIGHT_FD_READ, 0)
-                        .and_then(|fe| fe.fd_object.descriptor.as_file())?
+                        .get_fd_entry(wasi_fd, host::__WASI_RIGHT_FD_READ, 0)?
+                        .fd_object
+                        .descriptor
                         .as_raw_fd()
                 };
                 fd_events.push(FdEventData {
@@ -106,53 +114,84 @@ pub(crate) fn poll_oneoff(
                     userdata: event.userdata,
                 })
             }
+            host::__WASI_EVENTTYPE_FD_WRITE => {
+                let wasi_fd = unsafe { event.u.fd_readwrite.fd };
+                let fd = unsafe {
+                    wasi_ctx
+                        .get_fd_entry(wasi_fd, host::__WASI_RIGHT_FD_WRITE, 0)?
+                        .fd_object
+                        .descriptor
+                        .as_raw_fd()
+                };
+                fd_events.push(FdEventData {
+                    fd,
+                    type_: event.type_,
+                    userdata: event.userdata,
+                })
+            }
+            _ => unreachable!(),
         }
     }
 
+    log::debug!("poll_oneoff timeout = {:?}", timeout);
     log::debug!("poll_oneoff fd_events = {:?}", fd_events);
 
     if fd_events.is_empty() && timeout.is_none() {
-        return Ok(0);
+        return Ok(vec![]);
     }
+
     let mut poll_fds: Vec<_> = fd_events
         .iter()
         .map(|event| {
-            let mut flags = nix::poll::PollFlags::empty();
+            let mut flags = PollFlags::empty();
             match event.type_ {
-                wasm32::__WASI_EVENTTYPE_FD_READ => flags.insert(nix::poll::PollFlags::POLLIN),
-                wasm32::__WASI_EVENTTYPE_FD_WRITE => flags.insert(nix::poll::PollFlags::POLLOUT),
+                host::__WASI_EVENTTYPE_FD_READ => flags.insert(PollFlags::POLLIN),
+                host::__WASI_EVENTTYPE_FD_WRITE => flags.insert(PollFlags::POLLOUT),
                 // An event on a file descriptor can currently only be of type FD_READ or FD_WRITE
                 // Nothing else has been defined in the specification, and these are also the only two
                 // events we filtered before. If we get something else here, the code has a serious bug.
                 _ => unreachable!(),
             };
-            nix::poll::PollFd::new(event.fd, flags)
+            PollFd::new(event.fd, flags)
         })
         .collect();
+
     let timeout = timeout.map(|ClockEventData { delay, userdata }| ClockEventData {
         delay: cmp::min(delay, c_int::max_value() as u128),
         userdata,
     });
     let poll_timeout = timeout.map_or(-1, |timeout| timeout.delay as c_int);
     let ready = loop {
-        match nix::poll::poll(&mut poll_fds, poll_timeout) {
+        match poll(&mut poll_fds, poll_timeout) {
             Err(_) => {
-                if nix::errno::Errno::last() == nix::errno::Errno::EINTR {
+                if Errno::last() == Errno::EINTR {
                     continue;
                 }
-                return Err(host_impl::errno_from_nix(nix::errno::Errno::last()));
+                return Err(host_impl::errno_from_nix(Errno::last()));
             }
             Ok(ready) => break ready as usize,
         }
     };
-    let events_count = if ready == 0 {
-        poll_oneoff_handle_timeout_event(output_slice, timeout)
-    } else {
-        let events = fd_events.iter().zip(poll_fds.iter()).take(ready);
-        poll_oneoff_handle_fd_event(output_slice, events)
-    };
 
-    Ok(events_count)
+    if ready == 0 {
+        Ok(poll_oneoff_handle_timeout_event(timeout))
+    } else {
+        let events = fd_events.into_iter().zip(poll_fds.into_iter()).take(ready);
+        poll_oneoff_handle_fd_event(events)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+struct ClockEventData {
+    delay: u128,
+    userdata: host::__wasi_userdata_t,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct FdEventData {
+    fd: c_int,
+    type_: host::__wasi_eventtype_t,
+    userdata: host::__wasi_userdata_t,
 }
 
 // define the `fionread()` function, equivalent to `ioctl(fd, FIONREAD, *bytes)`
@@ -161,7 +200,7 @@ nix::ioctl_read_bad!(fionread, nix::libc::FIONREAD, c_int);
 fn wasi_clock_to_relative_ns_delay(
     wasi_clock: host::__wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
 ) -> Result<u128> {
-    if wasi_clock.flags != wasm32::__WASI_SUBSCRIPTION_CLOCK_ABSTIME {
+    if wasi_clock.flags != host::__WASI_SUBSCRIPTION_CLOCK_ABSTIME {
         return Ok(u128::from(wasi_clock.timeout));
     }
     let now: u128 = SystemTime::now()
@@ -172,49 +211,32 @@ fn wasi_clock_to_relative_ns_delay(
     Ok(deadline.saturating_sub(now))
 }
 
-#[derive(Debug, Copy, Clone)]
-struct ClockEventData {
-    delay: u128,
-    userdata: host::__wasi_userdata_t,
-}
-#[derive(Debug, Copy, Clone)]
-struct FdEventData {
-    fd: c_int,
-    type_: host::__wasi_eventtype_t,
-    userdata: host::__wasi_userdata_t,
-}
-
-fn poll_oneoff_handle_timeout_event(
-    output_slice: &mut [wasm32::__wasi_event_t],
-    timeout: Option<ClockEventData>,
-) -> wasm32::size_t {
+fn poll_oneoff_handle_timeout_event(timeout: Option<ClockEventData>) -> Vec<host::__wasi_event_t> {
     if let Some(ClockEventData { userdata, .. }) = timeout {
-        let output_event = host::__wasi_event_t {
+        vec![host::__wasi_event_t {
             userdata,
-            type_: wasm32::__WASI_EVENTTYPE_CLOCK,
-            error: wasm32::__WASI_ESUCCESS,
+            type_: host::__WASI_EVENTTYPE_CLOCK,
+            error: host::__WASI_ESUCCESS,
             u: host::__wasi_event_t___wasi_event_u {
                 fd_readwrite: host::__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t {
                     nbytes: 0,
                     flags: 0,
                 },
             },
-        };
-        output_slice[0] = enc_event(output_event);
-        1
+        }]
     } else {
         // shouldn't happen
-        0
+        vec![]
     }
 }
 
-fn poll_oneoff_handle_fd_event<'t>(
-    output_slice: &mut [wasm32::__wasi_event_t],
-    events: impl Iterator<Item = (&'t FdEventData, &'t nix::poll::PollFd)>,
-) -> wasm32::size_t {
-    let mut output_slice_cur = output_slice.iter_mut();
-    let mut revents_count = 0;
+fn poll_oneoff_handle_fd_event(
+    events: impl Iterator<Item = (FdEventData, nix::poll::PollFd)>,
+) -> Result<Vec<host::__wasi_event_t>> {
+    use nix::poll::PollFlags;
+    use std::convert::TryInto;
 
+    let mut output_events = Vec::new();
     for (fd_event, poll_fd) in events {
         log::debug!("poll_oneoff_handle_fd_event fd_event = {:?}", fd_event);
         log::debug!("poll_oneoff_handle_fd_event poll_fd = {:?}", poll_fd);
@@ -227,59 +249,58 @@ fn poll_oneoff_handle_fd_event<'t>(
         log::debug!("poll_oneoff_handle_fd_event revents = {:?}", revents);
 
         let mut nbytes = 0;
-        if fd_event.type_ == wasm32::__WASI_EVENTTYPE_FD_READ {
+        if fd_event.type_ == host::__WASI_EVENTTYPE_FD_READ {
             let _ = unsafe { fionread(fd_event.fd, &mut nbytes) };
         }
-        let output_event = if revents.contains(nix::poll::PollFlags::POLLNVAL) {
+
+        let output_event = if revents.contains(PollFlags::POLLNVAL) {
             host::__wasi_event_t {
                 userdata: fd_event.userdata,
                 type_: fd_event.type_,
-                error: wasm32::__WASI_EBADF,
+                error: host::__WASI_EBADF,
                 u: host::__wasi_event_t___wasi_event_u {
                     fd_readwrite:
                         host::__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t {
                             nbytes: 0,
-                            flags: wasm32::__WASI_EVENT_FD_READWRITE_HANGUP,
+                            flags: host::__WASI_EVENT_FD_READWRITE_HANGUP,
                         },
                 },
             }
-        } else if revents.contains(nix::poll::PollFlags::POLLERR) {
+        } else if revents.contains(PollFlags::POLLERR) {
             host::__wasi_event_t {
                 userdata: fd_event.userdata,
                 type_: fd_event.type_,
-                error: wasm32::__WASI_EIO,
+                error: host::__WASI_EIO,
                 u: host::__wasi_event_t___wasi_event_u {
                     fd_readwrite:
                         host::__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t {
                             nbytes: 0,
-                            flags: wasm32::__WASI_EVENT_FD_READWRITE_HANGUP,
+                            flags: host::__WASI_EVENT_FD_READWRITE_HANGUP,
                         },
                 },
             }
-        } else if revents.contains(nix::poll::PollFlags::POLLHUP) {
+        } else if revents.contains(PollFlags::POLLHUP) {
             host::__wasi_event_t {
                 userdata: fd_event.userdata,
                 type_: fd_event.type_,
-                error: wasm32::__WASI_ESUCCESS,
+                error: host::__WASI_ESUCCESS,
                 u: host::__wasi_event_t___wasi_event_u {
                     fd_readwrite:
                         host::__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t {
                             nbytes: 0,
-                            flags: wasm32::__WASI_EVENT_FD_READWRITE_HANGUP,
+                            flags: host::__WASI_EVENT_FD_READWRITE_HANGUP,
                         },
                 },
             }
-        } else if revents.contains(nix::poll::PollFlags::POLLIN)
-            | revents.contains(nix::poll::PollFlags::POLLOUT)
-        {
+        } else if revents.contains(PollFlags::POLLIN) | revents.contains(PollFlags::POLLOUT) {
             host::__wasi_event_t {
                 userdata: fd_event.userdata,
                 type_: fd_event.type_,
-                error: wasm32::__WASI_ESUCCESS,
+                error: host::__WASI_ESUCCESS,
                 u: host::__wasi_event_t___wasi_event_u {
                     fd_readwrite:
                         host::__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t {
-                            nbytes: nbytes as host::__wasi_filesize_t,
+                            nbytes: nbytes.try_into()?,
                             flags: 0,
                         },
                 },
@@ -287,8 +308,9 @@ fn poll_oneoff_handle_fd_event<'t>(
         } else {
             continue;
         };
-        *output_slice_cur.next().unwrap() = enc_event(output_event);
-        revents_count += 1;
+
+        output_events.push(output_event);
     }
-    revents_count
+
+    Ok(output_events)
 }

--- a/src/sys/unix/hostcalls_impl/misc.rs
+++ b/src/sys/unix/hostcalls_impl/misc.rs
@@ -98,8 +98,11 @@ pub(crate) fn poll_oneoff(
         .collect();
 
     let poll_timeout = timeout.map_or(-1, |timeout| {
-        timeout.delay.try_into().unwrap_or(c_int::max_value())
+        let delay = timeout.delay / 1_000_000; // poll syscall requires delay to expressed in milliseconds
+        delay.try_into().unwrap_or(c_int::max_value())
     });
+    log::debug!("poll_oneoff poll_timeout = {:?}", poll_timeout);
+
     let ready = loop {
         match poll(&mut poll_fds, poll_timeout) {
             Err(_) => {

--- a/src/sys/windows/hostcalls_impl/misc.rs
+++ b/src/sys/windows/hostcalls_impl/misc.rs
@@ -4,7 +4,7 @@
 use crate::helpers::systemtime_to_timestamp;
 use crate::memory::*;
 use crate::sys::host_impl;
-use crate::{host, wasm32, Error, Result};
+use crate::{ctx::WasiCtx, host, wasm32, Error, Result};
 use cpu_time::{ProcessTime, ThreadTime};
 use lazy_static::lazy_static;
 use std::convert::TryInto;
@@ -30,9 +30,9 @@ pub(crate) fn clock_time_get(clock_id: host::__wasi_clockid_t) -> Result<host::_
 }
 
 pub(crate) fn poll_oneoff(
-    input: Vec<Result<host::__wasi_subscription_t>>,
-    output_slice: &mut [wasm32::__wasi_event_t],
-) -> Result<wasm32::size_t> {
+    wasi_ctx: &WasiCtx,
+    input: impl Iterator<Item = Result<host::__wasi_subscription_t>>,
+) -> Result<Vec<host::__wasi_event_t>> {
     unimplemented!("poll_oneoff")
 }
 

--- a/src/sys/windows/hostcalls_impl/misc.rs
+++ b/src/sys/windows/hostcalls_impl/misc.rs
@@ -2,9 +2,10 @@
 #![allow(unused_unsafe)]
 #![allow(unused)]
 use crate::helpers::systemtime_to_timestamp;
+use crate::hostcalls_impl::{ClockEventData, FdEventData};
 use crate::memory::*;
 use crate::sys::host_impl;
-use crate::{ctx::WasiCtx, host, wasm32, Error, Result};
+use crate::{host, wasm32, Error, Result};
 use cpu_time::{ProcessTime, ThreadTime};
 use lazy_static::lazy_static;
 use std::convert::TryInto;
@@ -30,8 +31,8 @@ pub(crate) fn clock_time_get(clock_id: host::__wasi_clockid_t) -> Result<host::_
 }
 
 pub(crate) fn poll_oneoff(
-    wasi_ctx: &WasiCtx,
-    input: impl Iterator<Item = Result<host::__wasi_subscription_t>>,
+    timeout: Option<ClockEventData>,
+    fd_events: Vec<FdEventData>,
 ) -> Result<Vec<host::__wasi_event_t>> {
     unimplemented!("poll_oneoff")
 }


### PR DESCRIPTION
This PR introduces a couple of changes/fixes:
* it annotates `log::debug!` messages with "host" to differentiate
  between file descriptors stored on the WASI side (aka the wrappers)
  and those managed by the host (aka the wrapped)
* it fixes CraneStation/wasmtime#440, i.e., incorrect passing of
  file descriptor to `poll_oneoff` where currently errenously we
  pass in the wrapper instead of the wrapped value
* it adds a couple more `log::debug!` macros calls for easier future
  debugging
* it refactors `poll_oneoff` for easier maintenance in the future (hopefully!)