### PR TITLE
Sync with latest wasmtime rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,12 @@ winx = { path = "winx" }
 winapi = "0.3"
 
 [dev-dependencies]
-wasmtime-runtime = { git = "https://github.com/cranestation/wasmtime", rev = "cb38b48" }
-wasmtime-environ = { git = "https://github.com/cranestation/wasmtime", rev = "cb38b48" }
-wasmtime-jit = { git = "https://github.com/cranestation/wasmtime", rev = "cb38b48" }
-wasmtime-wasi = { git = "https://github.com/cranestation/wasmtime", rev = "cb38b48" }
-cranelift-codegen = "0.44.0"
-cranelift-entity = "0.44.0"
-cranelift-wasm = "0.44.0"
-cranelift-native = "0.44.0"
+wasmtime-runtime = { git = "https://github.com/cranestation/wasmtime", rev = "e37168a" }
+wasmtime-environ = { git = "https://github.com/cranestation/wasmtime", rev = "e37168a" }
+wasmtime-jit = { git = "https://github.com/cranestation/wasmtime", rev = "e37168a" }
+wasmtime-wasi = { git = "https://github.com/cranestation/wasmtime", rev = "e37168a" }
+wasmtime-api = { git = "https://github.com/cranestation/wasmtime", rev = "e37168a" }
+cranelift-codegen = "0.46.1"
 target-lexicon = "0.8.1"
 pretty_env_logger = "0.3.0"
 tempfile = "3.1.0"

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,16 +1,28 @@
-use cranelift_codegen::settings;
-use std::path::Path;
-use wasmtime_jit::Context;
+use cranelift_codegen::settings::{self, Configurable};
+use std::{collections::HashMap, path::Path};
+use wasmtime_api::{Config, Engine, HostRef, Instance, Module, Store};
+use wasmtime_jit::{CompilationStrategy, Features};
 
 pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> Result<(), String> {
     // Prepare runtime
-    let isa_builder =
-        cranelift_native::builder().map_err(|_| "host machine is not a supported target")?;
-    let flag_builder = settings::builder();
-    let isa = isa_builder.finish(settings::Flags::new(flag_builder));
-    let mut context = Context::with_isa(isa);
-    let global_exports = context.get_global_exports();
+    let mut flag_builder = settings::builder();
 
+    // Enable proper trap for division
+    flag_builder
+        .enable("avoid_div_traps")
+        .map_err(|err| format!("error while enabling proper division trap: {}", err))?;
+
+    let config = Config::new(
+        settings::Flags::new(flag_builder),
+        Features::default(),
+        false,
+        CompilationStrategy::Auto,
+    );
+    let engine = HostRef::new(Engine::new(config));
+    let store = HostRef::new(Store::new(engine));
+
+    let mut module_registry = HashMap::new();
+    let global_exports = store.borrow().global_exports().clone();
     let get_preopens = |workspace: Option<&Path>| -> Result<Vec<_>, String> {
         if let Some(workspace) = workspace {
             let preopen_dir = wasi_common::preopen_dir(workspace).map_err(|e| {
@@ -26,22 +38,55 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> Res
             Ok(vec![])
         }
     };
-
-    context.name_instance(
+    module_registry.insert(
         "wasi_unstable".to_owned(),
-        wasmtime_wasi::instantiate_wasi(
-            "",
-            global_exports,
-            &get_preopens(workspace)?,
-            &[bin_name.to_owned(), ".".to_owned()],
-            &[],
+        Instance::from_handle(
+            store.clone(),
+            wasmtime_wasi::instantiate_wasi(
+                "",
+                global_exports.clone(),
+                &get_preopens(workspace)?,
+                &[bin_name.to_owned(), ".".to_owned()],
+                &[],
+            )
+            .map_err(|e| format!("error instantiating WASI: {}", e))?,
         )
-        .map_err(|e| format!("error instantiating WASI: {}", e))?,
+        .map_err(|err| format!("error instantiating from handle: {}", err))?,
     );
 
-    // Compile and instantiating a wasm module.
-    context
-        .instantiate_module(None, &data)
-        .map(|_| ())
-        .map_err(|e| format!("error while processing main module '{}': {}", bin_name, e))
+    let module = HostRef::new(
+        Module::new(store.clone(), &data)
+            .map_err(|err| format!("error while creating Wasm module '{}': {}", bin_name, err))?,
+    );
+    let imports = module
+        .borrow()
+        .imports()
+        .iter()
+        .map(|i| {
+            let module_name = i.module().to_string();
+            if let Some((instance, map)) = module_registry.get(&module_name) {
+                let field_name = i.name().to_string();
+                if let Some(export_index) = map.get(&field_name) {
+                    Ok(instance.exports()[*export_index].clone())
+                } else {
+                    Err(format!(
+                        "import {} was not found in module {}",
+                        field_name, module_name
+                    ))
+                }
+            } else {
+                Err(format!("import module {} was not found", module_name))
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let _ = HostRef::new(
+        Instance::new(store.clone(), module.clone(), &imports).map_err(|err| {
+            format!(
+                "error while instantiating Wasm module '{}': {}",
+                bin_name, err
+            )
+        })?,
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
This commit syncs tests with latest wasmtime revision.
As such, it now utilises the `wasmtime-api` crate for
runtime setup.

Closes #126, #127, #128, #129.