### PR TITLE
Add more links in the `fs` module's documentation.

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -7,10 +7,13 @@ use std::io;
 /// This corresponds to [`std::fs::File`].
 ///
 /// Note that this `File` has no `open` or `create` methods. To open or create
-/// a file, you must first obtain a `Dir` containing the file, and then call
-/// `Dir::open_file` or `Dir::create_file`.
+/// a file, you must first obtain a [`Dir`] containing the file, and then call
+/// [`Dir::open_file`] or [`Dir::create_file`].
 ///
 /// [`std::fs::File`]: https://doc.rust-lang.org/std/fs/struct.File.html
+/// [`Dir`]: struct.Dir.html
+/// [`Dir::open_file`]: struct.Dir.html#method.open_file
+/// [`Dir::create_file`]: struct.Dir.html#method.create_file
 pub struct File<'ctx> {
     ctx: &'ctx mut WasiCtx,
     fd: host::__wasi_fd_t,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -7,7 +7,7 @@
 //! This corresponds to [`std::fs`].
 //!
 //! Instead of [`std::fs`'s free functions] which operate on paths, this
-//! crate has methods on `Dir` which operate on paths which must be
+//! crate has methods on [`Dir`] which operate on paths which must be
 //! relative to and within the directory.
 //!
 //! Since all functions which expose raw file descriptors are `unsafe`,
@@ -17,6 +17,7 @@
 //!
 //! [`std::fs`]: https://doc.rust-lang.org/std/fs/index.html
 //! [`std::fs`'s free functions]: https://doc.rust-lang.org/std/fs/index.html#functions
+//! [`DIR`]: struct.Dir.html
 
 // TODO: When more things are implemented, remove these.
 #![allow(

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -3,9 +3,12 @@
 /// This corresponds to [`std::fs::OpenOptions`].
 ///
 /// Note that this `OpenOptions` has no `open` method. To open a file with
-/// an `OptionOptions`, pass it to `Dir::open_file_with`.
+/// an `OptionOptions`, you must first obtain a [`Dir`] containing the file, and
+/// then call [`Dir::open_file_with`].
 ///
 /// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+/// [`Dir`]: struct.Dir.html
+/// [`Dir::open_file_with`]: struct.Dir.html#method.open_file_with
 pub struct OpenOptions {
     pub(crate) read: bool,
     pub(crate) write: bool,


### PR DESCRIPTION
`cargo doc` doesn't automatically link code-formatted identifiers, so add some explicit links in the documentation.