### PR TITLE
Remove `needs_close` from `FdObject`

### DIFF
--- a/src/fdentry.rs
+++ b/src/fdentry.rs
@@ -1,6 +1,5 @@
 use crate::sys::fdentry_impl::{determine_type_and_access_rights, OsFile};
 use crate::{host, Error, Result};
-use std::mem::ManuallyDrop;
 use std::path::PathBuf;
 use std::{fs, io};
 
@@ -62,8 +61,7 @@ impl Descriptor {
 #[derive(Debug)]
 pub(crate) struct FdObject {
     pub(crate) file_type: host::__wasi_filetype_t,
-    pub(crate) descriptor: ManuallyDrop<Descriptor>,
-    pub(crate) needs_close: bool,
+    pub(crate) descriptor: Descriptor,
     // TODO: directories
 }
 
@@ -75,22 +73,13 @@ pub(crate) struct FdEntry {
     pub(crate) preopen_path: Option<PathBuf>,
 }
 
-impl Drop for FdObject {
-    fn drop(&mut self) {
-        if self.needs_close {
-            unsafe { ManuallyDrop::drop(&mut self.descriptor) };
-        }
-    }
-}
-
 impl FdEntry {
     pub(crate) fn from(file: fs::File) -> Result<Self> {
         unsafe { determine_type_and_access_rights(&file) }.map(
             |(file_type, rights_base, rights_inheriting)| Self {
                 fd_object: FdObject {
                     file_type,
-                    descriptor: ManuallyDrop::new(Descriptor::OsFile(OsFile::from(file))),
-                    needs_close: true,
+                    descriptor: Descriptor::OsFile(OsFile::from(file)),
                 },
                 rights_base,
                 rights_inheriting,
@@ -108,8 +97,7 @@ impl FdEntry {
             |(file_type, rights_base, rights_inheriting)| Self {
                 fd_object: FdObject {
                     file_type,
-                    descriptor: ManuallyDrop::new(Descriptor::Stdin),
-                    needs_close: true,
+                    descriptor: Descriptor::Stdin,
                 },
                 rights_base,
                 rights_inheriting,
@@ -123,8 +111,7 @@ impl FdEntry {
             |(file_type, rights_base, rights_inheriting)| Self {
                 fd_object: FdObject {
                     file_type,
-                    descriptor: ManuallyDrop::new(Descriptor::Stdout),
-                    needs_close: true,
+                    descriptor: Descriptor::Stdout,
                 },
                 rights_base,
                 rights_inheriting,
@@ -138,8 +125,7 @@ impl FdEntry {
             |(file_type, rights_base, rights_inheriting)| Self {
                 fd_object: FdObject {
                     file_type,
-                    descriptor: ManuallyDrop::new(Descriptor::Stderr),
-                    needs_close: true,
+                    descriptor: Descriptor::Stderr,
                 },
                 rights_base,
                 rights_inheriting,


### PR DESCRIPTION
This commit removes `needs_close` field from `FdObject`, and stores the underlying `Descriptor` without the `ManuallyDrop` wrapper.

As per our discussion in #147.