### PR TITLE
Rebuild misc tests when any of test files change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,19 @@
 
 fn main() {
     #[cfg(feature = "wasm_tests")]
-    {
+    wasm_tests::build_and_generate_tests();
+}
+
+#[cfg(feature = "wasm_tests")]
+mod wasm_tests {
+    use std::env;
+    use std::fs::{read_dir, DirEntry, File};
+    use std::io::{self, Write};
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+
+    pub(crate) fn build_and_generate_tests() {
+        // Validate if any of test sources are present and if they changed
         let bin_tests = std::fs::read_dir("misc_testsuite/src/bin")
             .expect("wasm_tests feature requires initialized misc_testsuite: `git submodule update --init`?");
         for test in bin_tests {
@@ -21,19 +33,8 @@ fn main() {
                 println!("cargo:rerun-if-changed={}", test_file_path);
             }
         }
-        wasm_tests::build_and_generate_tests();
-    }
-}
 
-#[cfg(feature = "wasm_tests")]
-mod wasm_tests {
-    use std::env;
-    use std::fs::{read_dir, DirEntry, File};
-    use std::io::{self, Write};
-    use std::path::{Path, PathBuf};
-    use std::process::{Command, Stdio};
-
-    pub(crate) fn build_and_generate_tests() {
+        // Build tests to OUT_DIR (target/*/build/wasi-common-*/out/wasm32-wasi/release/*.wasm)
         let out_dir = PathBuf::from(
             env::var("OUT_DIR").expect("The OUT_DIR environment variable must be set"),
         );

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,11 @@ fn main() {
             .expect("wasm_tests feature requires initialized misc_testsuite: `git submodule update --init`?");
         for test in bin_tests {
             if let Ok(test_file) = test {
-                let test_file_path = test_file.path().into_os_string().into_string().expect("test file path");
+                let test_file_path = test_file
+                    .path()
+                    .into_os_string()
+                    .into_string()
+                    .expect("test file path");
                 println!("cargo:rerun-if-changed={}", test_file_path);
             }
         }

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,17 @@
 
 fn main() {
     #[cfg(feature = "wasm_tests")]
-    wasm_tests::build_and_generate_tests();
+    {
+        let bin_tests = std::fs::read_dir("misc_testsuite/src/bin")
+            .expect("wasm_tests feature requires initialized misc_testsuite: `git submodule update --init`?");
+        for test in bin_tests {
+            if let Ok(test_file) = test {
+                let test_file_path = test_file.path().into_os_string().into_string().expect("test file path");
+                println!("cargo:rerun-if-changed={}", test_file_path);
+            }
+        }
+        wasm_tests::build_and_generate_tests();
+    }
 }
 
 #[cfg(feature = "wasm_tests")]


### PR DESCRIPTION
Currently since wasm test sources reside in a standalone git module cargo does not notice changes in test files and does not trigger rebuild automatically when running `cargo test --features wasm_tests`. 

This PR adding validation for file changes residing under `misc_testsuite/src/bin`. Also it will panic early if git module not initialized while running tests with `wasm_tests` feature.

**Common build behavior not affected:**
```
wasi-common % cargo build                            
   Compiling wasi-common v0.4.0 (/Users/max/src/wasm/wasi-common)
    Finished dev [unoptimized + debuginfo] target(s) in 2.82s
wasi-common % cargo build
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
```

**wasm_tests feature first and second build:**
```
wasi-common % cargo test isatty --features wasm_tests
   Compiling wasi-common v0.4.0 (/Users/max/src/wasm/wasi-common)
   Compiling wasmtime-wasi v0.2.0 (https://github.com/cranestation/wasmtime?rev=875eea6#875eea60)
    Finished test [unoptimized + debuginfo] target(s) in 10.08s
     Running target/debug/deps/wasi_common-79076e10b24c098f

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 35 filtered out

     Running target/debug/deps/runtime-5e1bd1677381463c

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/utils-df23fe34f808d9f0

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/wasm_tests-57707c681c33a4dc

running 1 test
test misc_testsuite::isatty ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 28 filtered out

wasi-common % cargo test isatty --features wasm_tests
    Finished test [unoptimized + debuginfo] target(s) in 0.15s
     Running target/debug/deps/wasi_common-79076e10b24c098f

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 35 filtered out

     Running target/debug/deps/runtime-5e1bd1677381463c

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/utils-df23fe34f808d9f0

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/wasm_tests-57707c681c33a4dc

running 1 test
test misc_testsuite::isatty ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 28 filtered out
```

**after changing any file under `misc_testsuite/src/bin`:**
```
wasi-common % cargo test isatty --features wasm_tests
   Compiling wasi-common v0.4.0 (/Users/max/src/wasm/wasi-common)
   Compiling wasmtime-wasi v0.2.0 (https://github.com/cranestation/wasmtime?rev=875eea6#875eea60)
    Finished test [unoptimized + debuginfo] target(s) in 12.70s
     Running target/debug/deps/wasi_common-79076e10b24c098f

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 35 filtered out

     Running target/debug/deps/runtime-5e1bd1677381463c

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/utils-df23fe34f808d9f0

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/wasm_tests-57707c681c33a4dc

running 1 test
test misc_testsuite::isatty ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 28 filtered out

wasi-common % cargo test isatty --features wasm_tests
    Finished test [unoptimized + debuginfo] target(s) in 0.37s
     Running target/debug/deps/wasi_common-79076e10b24c098f

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 35 filtered out

     Running target/debug/deps/runtime-5e1bd1677381463c

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/utils-df23fe34f808d9f0

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/wasm_tests-57707c681c33a4dc

running 1 test
test misc_testsuite::isatty ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 28 filtered out
```