### PR TITLE
Use generated type bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -52,6 +54,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -99,6 +103,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "misc_testsuite"]
 	path = misc_testsuite
 	url = https://github.com/cranestation/wasi-misc-tests
+[submodule "WASI"]
+	path = WASI
+	url = https://github.com/WebAssembly/WASI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ log = "0.4"
 filetime = "0.2.7"
 lazy_static = "1.4.0"
 num = { version = "0.2.0", default-features = false }
+wig = { path = "wig", version = "0.0.0" }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.15"

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -83,7 +83,7 @@ impl<'ctx> io::Read for File<'ctx> {
     /// TODO: Not yet implemented. See the comment in `Dir::open_file`.
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let iov = [host::__wasi_iovec_t {
-            buf: buf.as_mut_ptr() as *mut core::ffi::c_void,
+            buf: buf.as_mut_ptr() as *mut u8,
             buf_len: buf.len(),
         }];
         let mut nread = 0;

--- a/src/host.rs
+++ b/src/host.rs
@@ -10,20 +10,8 @@ use wig::witx_host_types;
 
 witx_host_types!("unstable" "wasi_unstable_preview0");
 
-#[allow(unused)]
 pub(crate) unsafe fn ciovec_to_host(ciovec: &__wasi_ciovec_t) -> io::IoSlice {
     let slice = slice::from_raw_parts(ciovec.buf as *const u8, ciovec.buf_len);
-    io::IoSlice::new(slice)
-}
-
-#[allow(unused)]
-pub(crate) unsafe fn ciovec_to_host_mut(ciovec: &mut __wasi_ciovec_t) -> io::IoSliceMut {
-    let slice = slice::from_raw_parts_mut(ciovec.buf as *mut u8, ciovec.buf_len);
-    io::IoSliceMut::new(slice)
-}
-
-pub(crate) unsafe fn iovec_to_host(iovec: &__wasi_iovec_t) -> io::IoSlice {
-    let slice = slice::from_raw_parts(iovec.buf as *const u8, iovec.buf_len);
     io::IoSlice::new(slice)
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -6,42 +6,9 @@
 
 use crate::wasi::*;
 use std::{io, slice};
+use wig::witx_host_types;
 
-pub(crate) type void = ::std::os::raw::c_void;
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub(crate) struct __wasi_prestat_t {
-    pub(crate) pr_type: __wasi_preopentype_t,
-    pub(crate) u: __wasi_prestat_t___wasi_prestat_u,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub(crate) union __wasi_prestat_t___wasi_prestat_u {
-    pub(crate) dir: __wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t,
-    _bindgen_union_align: u64,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct __wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
-    pub(crate) pr_name_len: usize,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct __wasi_ciovec_t {
-    pub(crate) buf: *const void,
-    pub(crate) buf_len: usize,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct __wasi_iovec_t {
-    pub(crate) buf: *mut void,
-    pub(crate) buf_len: usize,
-}
+witx_host_types!("unstable" "wasi_unstable_preview0");
 
 #[allow(unused)]
 pub(crate) unsafe fn ciovec_to_host(ciovec: &__wasi_ciovec_t) -> io::IoSlice {
@@ -105,30 +72,23 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t>(),
+            ::std::mem::size_of::<__wasi_prestat_dir>(),
             8usize,
-            concat!(
-                "Size of: ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t)
-            )
+            concat!("Size of: ", stringify!(__wasi_prestat_dir))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t>(),
+            ::std::mem::align_of::<__wasi_prestat_dir>(),
             8usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t)
-            )
+            concat!("Alignment of ", stringify!(__wasi_prestat_dir))
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t>()))
-                    .pr_name_len as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_prestat_dir>())).pr_name_len as *const _ as usize
             },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t),
+                stringify!(__wasi_prestat_dir),
                 "::",
                 stringify!(pr_name_len)
             )
@@ -138,27 +98,21 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_prestat_t___wasi_prestat_u() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_prestat_t___wasi_prestat_u>(),
+            ::std::mem::size_of::<__wasi_prestat_u>(),
             8usize,
-            concat!("Size of: ", stringify!(__wasi_prestat_t___wasi_prestat_u))
+            concat!("Size of: ", stringify!(__wasi_prestat_u))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_prestat_t___wasi_prestat_u>(),
+            ::std::mem::align_of::<__wasi_prestat_u>(),
             8usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u)
-            )
+            concat!("Alignment of ", stringify!(__wasi_prestat_u))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_prestat_t___wasi_prestat_u>())).dir as *const _
-                    as usize
-            },
+            unsafe { &(*(::std::ptr::null::<__wasi_prestat_u>())).dir as *const _ as usize },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u),
+                stringify!(__wasi_prestat_u),
                 "::",
                 stringify!(dir)
             )

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -986,8 +986,8 @@ pub(crate) unsafe fn fd_prestat_get(
         prestat_ptr,
         host::__wasi_prestat_t {
             pr_type: wasi::__WASI_PREOPENTYPE_DIR,
-            u: host::__wasi_prestat_t___wasi_prestat_u {
-                dir: host::__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
+            u: host::__wasi_prestat_u {
+                dir: host::__wasi_prestat_dir {
                     pr_name_len: path.len(),
                 },
             },

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -110,7 +110,7 @@ pub(crate) unsafe fn fd_pwrite(
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHT_FD_WRITE, 0)?
         .as_file()?;
-    let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
+    let iovs = dec_ciovec_slice(memory, iovs_ptr, iovs_len)?;
 
     if offset > i64::max_value() as u64 {
         return Err(Error::EIO);
@@ -352,8 +352,8 @@ pub(crate) unsafe fn fd_write(
         nwritten
     );
 
-    let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
-    let iovs: Vec<io::IoSlice> = iovs.iter().map(|vec| host::iovec_to_host(vec)).collect();
+    let iovs = dec_ciovec_slice(memory, iovs_ptr, iovs_len)?;
+    let iovs: Vec<io::IoSlice> = iovs.iter().map(|vec| host::ciovec_to_host(vec)).collect();
 
     // perform unbuffered writes
     let host_nwritten = match wasi_ctx

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -6,117 +6,9 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-// C types
-pub type char = i8;
-pub type schar = i8;
-pub type uchar = u8;
-pub type short = i16;
-pub type ushort = u16;
-pub type int = i32;
-pub type uint = u32;
-pub type longlong = i64;
-pub type ulonglong = u64;
+use wig::witx_wasi_types;
 
-// libc stdint types
-pub type int8_t = i8;
-pub type uint8_t = u8;
-pub type int16_t = i16;
-pub type uint16_t = u16;
-pub type int32_t = i32;
-pub type uint32_t = u32;
-pub type int64_t = i64;
-pub type uint64_t = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i32;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u32;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type wchar_t = i32;
-
-// libc types
-pub type dev_t = u64;
-pub type uid_t = u32;
-pub type gid_t = u32;
-pub type ino_t = u64;
-pub type ino64_t = u64;
-pub type mode_t = u32;
-pub type nlink_t = u64;
-pub type off_t = i64;
-pub type off64_t = i64;
-pub type pid_t = i32;
-pub type clock_t = i64;
-pub type rlim_t = u64;
-pub type rlim64_t = u64;
-pub type id_t = u32;
-pub type time_t = i64;
-pub type useconds_t = u32;
-pub type suseconds_t = i64;
-pub type daddr_t = i32;
-pub type key_t = i32;
-pub type clockid_t = i32;
-pub type blksize_t = i64;
-pub type blkcnt_t = i64;
-pub type blkcnt64_t = i64;
-pub type fsblkcnt_t = u64;
-pub type fsblkcnt64_t = u64;
-pub type fsfilcnt_t = u64;
-pub type fsfilcnt64_t = u64;
-pub type fsword_t = i64;
-pub type ssize_t = i32;
-pub type loff_t = off64_t;
-pub type socklen_t = u32;
-pub type sig_atomic_t = i32;
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsid_t {
-    pub __val: [i32; 2usize],
-}
-
-// WASI types
-pub type __wasi_advice_t = u8;
-pub type __wasi_clockid_t = u32;
-pub type __wasi_device_t = u64;
-pub type __wasi_dircookie_t = u64;
-pub type __wasi_errno_t = u16;
-pub type __wasi_eventrwflags_t = u16;
-pub type __wasi_eventtype_t = u8;
-pub type __wasi_exitcode_t = u32;
-pub type __wasi_fd_t = u32;
-pub type __wasi_fdflags_t = u16;
-pub type __wasi_fdsflags_t = u16;
-pub type __wasi_filedelta_t = i64;
-pub type __wasi_filesize_t = u64;
-pub type __wasi_filetype_t = u8;
-pub type __wasi_preopentype_t = u8;
-pub type __wasi_fstflags_t = u16;
-pub type __wasi_inode_t = u64;
-pub type __wasi_linkcount_t = u32;
-pub type __wasi_lookupflags_t = u32;
-pub type __wasi_oflags_t = u16;
-pub type __wasi_riflags_t = u16;
-pub type __wasi_rights_t = u64;
-pub type __wasi_roflags_t = u16;
-pub type __wasi_sdflags_t = u8;
-pub type __wasi_siflags_t = u16;
-pub type __wasi_signal_t = u8;
-pub type __wasi_subclockflags_t = u16;
-pub type __wasi_timestamp_t = u64;
-pub type __wasi_userdata_t = u64;
-pub type __wasi_whence_t = u8;
+witx_wasi_types!("unstable" "wasi_unstable_preview0");
 
 pub(crate) const RIGHTS_ALL: __wasi_rights_t = __WASI_RIGHT_FD_DATASYNC
     | __WASI_RIGHT_FD_READ
@@ -215,122 +107,6 @@ pub(crate) const RIGHTS_TTY_BASE: __wasi_rights_t = __WASI_RIGHT_FD_READ
 #[allow(unused)]
 pub(crate) const RIGHTS_TTY_INHERITING: __wasi_rights_t = 0;
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_dirent_t {
-    pub d_next: __wasi_dircookie_t,
-    pub d_ino: __wasi_inode_t,
-    pub d_namlen: u32,
-    pub d_type: __wasi_filetype_t,
-    pub __bindgen_padding_0: [u8; 3usize],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __wasi_event_t {
-    pub userdata: __wasi_userdata_t,
-    pub error: __wasi_errno_t,
-    pub type_: __wasi_eventtype_t,
-    pub __bindgen_padding_0: u32,
-    pub u: __wasi_event_t___wasi_event_u,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __wasi_event_t___wasi_event_u {
-    pub fd_readwrite: __wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t,
-    _bindgen_union_align: [u64; 2usize],
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t {
-    pub nbytes: __wasi_filesize_t,
-    pub flags: __wasi_eventrwflags_t,
-    pub __bindgen_padding_0: [u16; 3usize],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __wasi_event_t__bindgen_ty_1 {
-    pub fd_readwrite: __wasi_event_t__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: [u64; 2usize],
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_event_t__bindgen_ty_1__bindgen_ty_1 {
-    pub nbytes: __wasi_filesize_t,
-    pub flags: __wasi_eventrwflags_t,
-    pub __bindgen_padding_0: [u16; 3usize],
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_event_t__bindgen_ty_1__bindgen_ty_2 {
-    pub signal: __wasi_signal_t,
-    pub exitcode: __wasi_exitcode_t,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_fdstat_t {
-    pub fs_filetype: __wasi_filetype_t,
-    pub fs_flags: __wasi_fdflags_t,
-    pub __bindgen_padding_0: u32,
-    pub fs_rights_base: __wasi_rights_t,
-    pub fs_rights_inheriting: __wasi_rights_t,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_filestat_t {
-    pub st_dev: __wasi_device_t,
-    pub st_ino: __wasi_inode_t,
-    pub st_filetype: __wasi_filetype_t,
-    pub st_nlink: __wasi_linkcount_t,
-    pub st_size: __wasi_filesize_t,
-    pub st_atim: __wasi_timestamp_t,
-    pub st_mtim: __wasi_timestamp_t,
-    pub st_ctim: __wasi_timestamp_t,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __wasi_subscription_t {
-    pub userdata: __wasi_userdata_t,
-    pub type_: __wasi_eventtype_t,
-    pub __bindgen_padding_0: u32,
-    pub u: __wasi_subscription_t___wasi_subscription_u,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __wasi_subscription_t___wasi_subscription_u {
-    pub clock: __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-    pub fd_readwrite:
-        __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t,
-    _bindgen_union_align: [u64; 5usize],
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t {
-    pub identifier: __wasi_userdata_t,
-    pub clock_id: __wasi_clockid_t,
-    pub __bindgen_padding_0: u32,
-    pub timeout: __wasi_timestamp_t,
-    pub precision: __wasi_timestamp_t,
-    pub flags: __wasi_subclockflags_t,
-    pub __bindgen_padding_1: [u16; 3usize],
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t {
-    pub fd: __wasi_fd_t,
-}
-
 pub fn strerror(errno: __wasi_errno_t) -> &'static str {
     match errno {
         __WASI_ESUCCESS => "__WASI_ESUCCESS",
@@ -423,249 +199,11 @@ pub fn whence_to_str(whence: __wasi_whence_t) -> &'static str {
     }
 }
 
-// libc constants
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -2147483648;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 2147483647;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 4294967295;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: i32 = 2147483647;
-
-// WASI constants
-pub const __WASI_ADVICE_NORMAL: __wasi_advice_t = 0;
-pub const __WASI_ADVICE_SEQUENTIAL: __wasi_advice_t = 1;
-pub const __WASI_ADVICE_RANDOM: __wasi_advice_t = 2;
-pub const __WASI_ADVICE_WILLNEED: __wasi_advice_t = 3;
-pub const __WASI_ADVICE_DONTNEED: __wasi_advice_t = 4;
-pub const __WASI_ADVICE_NOREUSE: __wasi_advice_t = 5;
-pub const __WASI_CLOCK_REALTIME: __wasi_clockid_t = 0;
-pub const __WASI_CLOCK_MONOTONIC: __wasi_clockid_t = 1;
-pub const __WASI_CLOCK_PROCESS_CPUTIME_ID: __wasi_clockid_t = 2;
-pub const __WASI_CLOCK_THREAD_CPUTIME_ID: __wasi_clockid_t = 3;
 pub const __WASI_DIRCOOKIE_START: __wasi_dircookie_t = 0;
-pub const __WASI_ESUCCESS: __wasi_errno_t = 0;
-pub const __WASI_E2BIG: __wasi_errno_t = 1;
-pub const __WASI_EACCES: __wasi_errno_t = 2;
-pub const __WASI_EADDRINUSE: __wasi_errno_t = 3;
-pub const __WASI_EADDRNOTAVAIL: __wasi_errno_t = 4;
-pub const __WASI_EAFNOSUPPORT: __wasi_errno_t = 5;
-pub const __WASI_EAGAIN: __wasi_errno_t = 6;
-pub const __WASI_EALREADY: __wasi_errno_t = 7;
-pub const __WASI_EBADF: __wasi_errno_t = 8;
-pub const __WASI_EBADMSG: __wasi_errno_t = 9;
-pub const __WASI_EBUSY: __wasi_errno_t = 10;
-pub const __WASI_ECANCELED: __wasi_errno_t = 11;
-pub const __WASI_ECHILD: __wasi_errno_t = 12;
-pub const __WASI_ECONNABORTED: __wasi_errno_t = 13;
-pub const __WASI_ECONNREFUSED: __wasi_errno_t = 14;
-pub const __WASI_ECONNRESET: __wasi_errno_t = 15;
-pub const __WASI_EDEADLK: __wasi_errno_t = 16;
-pub const __WASI_EDESTADDRREQ: __wasi_errno_t = 17;
-pub const __WASI_EDOM: __wasi_errno_t = 18;
-pub const __WASI_EDQUOT: __wasi_errno_t = 19;
-pub const __WASI_EEXIST: __wasi_errno_t = 20;
-pub const __WASI_EFAULT: __wasi_errno_t = 21;
-pub const __WASI_EFBIG: __wasi_errno_t = 22;
-pub const __WASI_EHOSTUNREACH: __wasi_errno_t = 23;
-pub const __WASI_EIDRM: __wasi_errno_t = 24;
-pub const __WASI_EILSEQ: __wasi_errno_t = 25;
-pub const __WASI_EINPROGRESS: __wasi_errno_t = 26;
-pub const __WASI_EINTR: __wasi_errno_t = 27;
-pub const __WASI_EINVAL: __wasi_errno_t = 28;
-pub const __WASI_EIO: __wasi_errno_t = 29;
-pub const __WASI_EISCONN: __wasi_errno_t = 30;
-pub const __WASI_EISDIR: __wasi_errno_t = 31;
-pub const __WASI_ELOOP: __wasi_errno_t = 32;
-pub const __WASI_EMFILE: __wasi_errno_t = 33;
-pub const __WASI_EMLINK: __wasi_errno_t = 34;
-pub const __WASI_EMSGSIZE: __wasi_errno_t = 35;
-pub const __WASI_EMULTIHOP: __wasi_errno_t = 36;
-pub const __WASI_ENAMETOOLONG: __wasi_errno_t = 37;
-pub const __WASI_ENETDOWN: __wasi_errno_t = 38;
-pub const __WASI_ENETRESET: __wasi_errno_t = 39;
-pub const __WASI_ENETUNREACH: __wasi_errno_t = 40;
-pub const __WASI_ENFILE: __wasi_errno_t = 41;
-pub const __WASI_ENOBUFS: __wasi_errno_t = 42;
-pub const __WASI_ENODEV: __wasi_errno_t = 43;
-pub const __WASI_ENOENT: __wasi_errno_t = 44;
-pub const __WASI_ENOEXEC: __wasi_errno_t = 45;
-pub const __WASI_ENOLCK: __wasi_errno_t = 46;
-pub const __WASI_ENOLINK: __wasi_errno_t = 47;
-pub const __WASI_ENOMEM: __wasi_errno_t = 48;
-pub const __WASI_ENOMSG: __wasi_errno_t = 49;
-pub const __WASI_ENOPROTOOPT: __wasi_errno_t = 50;
-pub const __WASI_ENOSPC: __wasi_errno_t = 51;
-pub const __WASI_ENOSYS: __wasi_errno_t = 52;
-pub const __WASI_ENOTCONN: __wasi_errno_t = 53;
-pub const __WASI_ENOTDIR: __wasi_errno_t = 54;
-pub const __WASI_ENOTEMPTY: __wasi_errno_t = 55;
-pub const __WASI_ENOTRECOVERABLE: __wasi_errno_t = 56;
-pub const __WASI_ENOTSOCK: __wasi_errno_t = 57;
-pub const __WASI_ENOTSUP: __wasi_errno_t = 58;
-pub const __WASI_ENOTTY: __wasi_errno_t = 59;
-pub const __WASI_ENXIO: __wasi_errno_t = 60;
-pub const __WASI_EOVERFLOW: __wasi_errno_t = 61;
-pub const __WASI_EOWNERDEAD: __wasi_errno_t = 62;
-pub const __WASI_EPERM: __wasi_errno_t = 63;
-pub const __WASI_EPIPE: __wasi_errno_t = 64;
-pub const __WASI_EPROTO: __wasi_errno_t = 65;
-pub const __WASI_EPROTONOSUPPORT: __wasi_errno_t = 66;
-pub const __WASI_EPROTOTYPE: __wasi_errno_t = 67;
-pub const __WASI_ERANGE: __wasi_errno_t = 68;
-pub const __WASI_EROFS: __wasi_errno_t = 69;
-pub const __WASI_ESPIPE: __wasi_errno_t = 70;
-pub const __WASI_ESRCH: __wasi_errno_t = 71;
-pub const __WASI_ESTALE: __wasi_errno_t = 72;
-pub const __WASI_ETIMEDOUT: __wasi_errno_t = 73;
-pub const __WASI_ETXTBSY: __wasi_errno_t = 74;
-pub const __WASI_EXDEV: __wasi_errno_t = 75;
-pub const __WASI_ENOTCAPABLE: __wasi_errno_t = 76;
-pub const __WASI_EVENT_FD_READWRITE_HANGUP: __wasi_eventrwflags_t = 1;
-pub const __WASI_EVENTTYPE_CLOCK: __wasi_eventtype_t = 0;
-pub const __WASI_EVENTTYPE_FD_READ: __wasi_eventtype_t = 1;
-pub const __WASI_EVENTTYPE_FD_WRITE: __wasi_eventtype_t = 2;
-pub const __WASI_FDFLAG_APPEND: __wasi_fdflags_t = 1;
-pub const __WASI_FDFLAG_DSYNC: __wasi_fdflags_t = 2;
-pub const __WASI_FDFLAG_NONBLOCK: __wasi_fdflags_t = 4;
-pub const __WASI_FDFLAG_RSYNC: __wasi_fdflags_t = 8;
-pub const __WASI_FDFLAG_SYNC: __wasi_fdflags_t = 16;
-pub const __WASI_PREOPENTYPE_DIR: __wasi_preopentype_t = 0;
-pub const __WASI_FILETYPE_UNKNOWN: __wasi_filetype_t = 0;
-pub const __WASI_FILETYPE_BLOCK_DEVICE: __wasi_filetype_t = 1;
-pub const __WASI_FILETYPE_CHARACTER_DEVICE: __wasi_filetype_t = 2;
-pub const __WASI_FILETYPE_DIRECTORY: __wasi_filetype_t = 3;
-pub const __WASI_FILETYPE_REGULAR_FILE: __wasi_filetype_t = 4;
-pub const __WASI_FILETYPE_SOCKET_DGRAM: __wasi_filetype_t = 5;
-pub const __WASI_FILETYPE_SOCKET_STREAM: __wasi_filetype_t = 6;
-pub const __WASI_FILETYPE_SYMBOLIC_LINK: __wasi_filetype_t = 7;
-pub const __WASI_FILESTAT_SET_ATIM: __wasi_fstflags_t = 1;
-pub const __WASI_FILESTAT_SET_ATIM_NOW: __wasi_fstflags_t = 2;
-pub const __WASI_FILESTAT_SET_MTIM: __wasi_fstflags_t = 4;
-pub const __WASI_FILESTAT_SET_MTIM_NOW: __wasi_fstflags_t = 8;
-pub const __WASI_LOOKUP_SYMLINK_FOLLOW: __wasi_lookupflags_t = 1;
-pub const __WASI_O_CREAT: __wasi_oflags_t = 1;
-pub const __WASI_O_DIRECTORY: __wasi_oflags_t = 2;
-pub const __WASI_O_EXCL: __wasi_oflags_t = 4;
-pub const __WASI_O_TRUNC: __wasi_oflags_t = 8;
-pub const __WASI_SOCK_RECV_PEEK: __wasi_riflags_t = 1;
-pub const __WASI_SOCK_RECV_WAITALL: __wasi_riflags_t = 2;
-pub const __WASI_RIGHT_FD_DATASYNC: __wasi_rights_t = 1;
-pub const __WASI_RIGHT_FD_READ: __wasi_rights_t = 2;
-pub const __WASI_RIGHT_FD_SEEK: __wasi_rights_t = 4;
-pub const __WASI_RIGHT_FD_FDSTAT_SET_FLAGS: __wasi_rights_t = 8;
-pub const __WASI_RIGHT_FD_SYNC: __wasi_rights_t = 16;
-pub const __WASI_RIGHT_FD_TELL: __wasi_rights_t = 32;
-pub const __WASI_RIGHT_FD_WRITE: __wasi_rights_t = 64;
-pub const __WASI_RIGHT_FD_ADVISE: __wasi_rights_t = 128;
-pub const __WASI_RIGHT_FD_ALLOCATE: __wasi_rights_t = 256;
-pub const __WASI_RIGHT_PATH_CREATE_DIRECTORY: __wasi_rights_t = 512;
-pub const __WASI_RIGHT_PATH_CREATE_FILE: __wasi_rights_t = 1024;
-pub const __WASI_RIGHT_PATH_LINK_SOURCE: __wasi_rights_t = 2048;
-pub const __WASI_RIGHT_PATH_LINK_TARGET: __wasi_rights_t = 4096;
-pub const __WASI_RIGHT_PATH_OPEN: __wasi_rights_t = 8192;
-pub const __WASI_RIGHT_FD_READDIR: __wasi_rights_t = 16384;
-pub const __WASI_RIGHT_PATH_READLINK: __wasi_rights_t = 32768;
-pub const __WASI_RIGHT_PATH_RENAME_SOURCE: __wasi_rights_t = 65536;
-pub const __WASI_RIGHT_PATH_RENAME_TARGET: __wasi_rights_t = 131072;
-pub const __WASI_RIGHT_PATH_FILESTAT_GET: __wasi_rights_t = 262144;
-pub const __WASI_RIGHT_PATH_FILESTAT_SET_SIZE: __wasi_rights_t = 524288;
-pub const __WASI_RIGHT_PATH_FILESTAT_SET_TIMES: __wasi_rights_t = 1048576;
-pub const __WASI_RIGHT_FD_FILESTAT_GET: __wasi_rights_t = 2097152;
-pub const __WASI_RIGHT_FD_FILESTAT_SET_SIZE: __wasi_rights_t = 4194304;
-pub const __WASI_RIGHT_FD_FILESTAT_SET_TIMES: __wasi_rights_t = 8388608;
-pub const __WASI_RIGHT_PATH_SYMLINK: __wasi_rights_t = 16777216;
-pub const __WASI_RIGHT_PATH_REMOVE_DIRECTORY: __wasi_rights_t = 33554432;
-pub const __WASI_RIGHT_PATH_UNLINK_FILE: __wasi_rights_t = 67108864;
-pub const __WASI_RIGHT_POLL_FD_READWRITE: __wasi_rights_t = 134217728;
-pub const __WASI_RIGHT_SOCK_SHUTDOWN: __wasi_rights_t = 268435456;
-pub const __WASI_SOCK_RECV_DATA_TRUNCATED: __wasi_roflags_t = 1;
-pub const __WASI_SHUT_RD: __wasi_sdflags_t = 1;
-pub const __WASI_SHUT_WR: __wasi_sdflags_t = 2;
-pub const __WASI_SIGHUP: __wasi_signal_t = 1;
-pub const __WASI_SIGINT: __wasi_signal_t = 2;
-pub const __WASI_SIGQUIT: __wasi_signal_t = 3;
-pub const __WASI_SIGILL: __wasi_signal_t = 4;
-pub const __WASI_SIGTRAP: __wasi_signal_t = 5;
-pub const __WASI_SIGABRT: __wasi_signal_t = 6;
-pub const __WASI_SIGBUS: __wasi_signal_t = 7;
-pub const __WASI_SIGFPE: __wasi_signal_t = 8;
-pub const __WASI_SIGKILL: __wasi_signal_t = 9;
-pub const __WASI_SIGUSR1: __wasi_signal_t = 10;
-pub const __WASI_SIGSEGV: __wasi_signal_t = 11;
-pub const __WASI_SIGUSR2: __wasi_signal_t = 12;
-pub const __WASI_SIGPIPE: __wasi_signal_t = 13;
-pub const __WASI_SIGALRM: __wasi_signal_t = 14;
-pub const __WASI_SIGTERM: __wasi_signal_t = 15;
-pub const __WASI_SIGCHLD: __wasi_signal_t = 16;
-pub const __WASI_SIGCONT: __wasi_signal_t = 17;
-pub const __WASI_SIGSTOP: __wasi_signal_t = 18;
-pub const __WASI_SIGTSTP: __wasi_signal_t = 19;
-pub const __WASI_SIGTTIN: __wasi_signal_t = 20;
-pub const __WASI_SIGTTOU: __wasi_signal_t = 21;
-pub const __WASI_SIGURG: __wasi_signal_t = 22;
-pub const __WASI_SIGXCPU: __wasi_signal_t = 23;
-pub const __WASI_SIGXFSZ: __wasi_signal_t = 24;
-pub const __WASI_SIGVTALRM: __wasi_signal_t = 25;
-pub const __WASI_SIGPROF: __wasi_signal_t = 26;
-pub const __WASI_SIGWINCH: __wasi_signal_t = 27;
-pub const __WASI_SIGPOLL: __wasi_signal_t = 28;
-pub const __WASI_SIGPWR: __wasi_signal_t = 29;
-pub const __WASI_SIGSYS: __wasi_signal_t = 30;
-pub const __WASI_SUBSCRIPTION_CLOCK_ABSTIME: __wasi_subclockflags_t = 1;
-pub const __WASI_WHENCE_CUR: __wasi_whence_t = 0;
-pub const __WASI_WHENCE_END: __wasi_whence_t = 1;
-pub const __WASI_WHENCE_SET: __wasi_whence_t = 2;
 
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn bindgen_test_layout_fsid_t() {
-        assert_eq!(
-            ::std::mem::size_of::<fsid_t>(),
-            8usize,
-            concat!("Size of: ", stringify!(fsid_t))
-        );
-        assert_eq!(
-            ::std::mem::align_of::<fsid_t>(),
-            4usize,
-            concat!("Alignment of ", stringify!(fsid_t))
-        );
-        assert_eq!(
-            unsafe { &(*(::std::ptr::null::<fsid_t>())).__val as *const _ as usize },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(fsid_t),
-                "::",
-                stringify!(__val)
-            )
-        );
-    }
 
     #[test]
     fn bindgen_test_layout_wasi_dirent_t() {
@@ -719,45 +257,35 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t>(),
+            ::std::mem::size_of::<__wasi_event_fd_readwrite_t>(),
             16usize,
-            concat!(
-                "Size of: ",
-                stringify!(__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t)
-            )
+            concat!("Size of: ", stringify!(__wasi_event_fd_readwrite_t))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t>(),
+            ::std::mem::align_of::<__wasi_event_fd_readwrite_t>(),
             8usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t)
-            )
+            concat!("Alignment of ", stringify!(__wasi_event_fd_readwrite_t))
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t>(
-                )))
-                .nbytes as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_event_fd_readwrite_t>())).nbytes as *const _ as usize
             },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t),
+                stringify!(__wasi_event_fd_readwrite_t),
                 "::",
                 stringify!(nbytes)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t>(
-                )))
-                .flags as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_event_fd_readwrite_t>())).flags as *const _ as usize
             },
             8usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t),
+                stringify!(__wasi_event_fd_readwrite_t),
                 "::",
                 stringify!(flags)
             )
@@ -767,24 +295,21 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_event_t___wasi_event_u() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_event_t___wasi_event_u>(),
+            ::std::mem::size_of::<__wasi_event_u>(),
             16usize,
-            concat!("Size of: ", stringify!(__wasi_event_t___wasi_event_u))
+            concat!("Size of: ", stringify!(__wasi_event_u))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_event_t___wasi_event_u>(),
+            ::std::mem::align_of::<__wasi_event_u>(),
             8usize,
-            concat!("Alignment of ", stringify!(__wasi_event_t___wasi_event_u))
+            concat!("Alignment of ", stringify!(__wasi_event_u))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t___wasi_event_u>())).fd_readwrite as *const _
-                    as usize
-            },
+            unsafe { &(*(::std::ptr::null::<__wasi_event_u>())).fd_readwrite as *const _ as usize },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_event_t___wasi_event_u),
+                stringify!(__wasi_event_u),
                 "::",
                 stringify!(fd_readwrite)
             )
@@ -824,13 +349,13 @@ mod test {
             )
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<__wasi_event_t>())).type_ as *const _ as usize },
+            unsafe { &(*(::std::ptr::null::<__wasi_event_t>())).r#type as *const _ as usize },
             10usize,
             concat!(
                 "Offset of field: ",
                 stringify!(__wasi_event_t),
                 "::",
-                stringify!(type_)
+                stringify!(r#type)
             )
         );
         assert_eq!(
@@ -841,112 +366,6 @@ mod test {
                 stringify!(__wasi_event_t),
                 "::",
                 stringify!(u)
-            )
-        );
-    }
-
-    #[test]
-    fn bindgen_test_layout_wasi_event_t__bindgen_ty_1__bindgen_ty_1() {
-        assert_eq!(
-            ::std::mem::size_of::<__wasi_event_t__bindgen_ty_1__bindgen_ty_1>(),
-            16usize,
-            concat!(
-                "Size of: ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_1)
-            )
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t__bindgen_ty_1__bindgen_ty_1>())).nbytes
-                    as *const _ as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(nbytes)
-            )
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t__bindgen_ty_1__bindgen_ty_1>())).flags
-                    as *const _ as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(flags)
-            )
-        );
-    }
-
-    #[test]
-    fn bindgen_test_layout_wasi_event_t__bindgen_ty_1__bindgen_ty_2() {
-        assert_eq!(
-            ::std::mem::size_of::<__wasi_event_t__bindgen_ty_1__bindgen_ty_2>(),
-            8usize,
-            concat!(
-                "Size of: ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_2)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<__wasi_event_t__bindgen_ty_1__bindgen_ty_2>(),
-            4usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_2)
-            )
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t__bindgen_ty_1__bindgen_ty_2>())).signal
-                    as *const _ as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(signal)
-            )
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t__bindgen_ty_1__bindgen_ty_2>())).exitcode
-                    as *const _ as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(__wasi_event_t__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(exitcode)
-            )
-        );
-    }
-
-    #[test]
-    fn bindgen_test_layout_wasi_event_t__bindgen_ty_1() {
-        assert_eq!(
-            ::std::mem::size_of::<__wasi_event_t__bindgen_ty_1>(),
-            16usize,
-            concat!("Size of: ", stringify!(__wasi_event_t__bindgen_ty_1))
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_event_t__bindgen_ty_1>())).fd_readwrite as *const _
-                    as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(__wasi_event_t__bindgen_ty_1),
-                "::",
-                stringify!(fd_readwrite)
             )
         );
     }
@@ -979,13 +398,13 @@ mod test {
             )
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<__wasi_event_t>())).type_ as *const _ as usize },
+            unsafe { &(*(::std::ptr::null::<__wasi_event_t>())).r#type as *const _ as usize },
             10usize,
             concat!(
                 "Offset of field: ",
                 stringify!(__wasi_event_t),
                 "::",
-                stringify!(type_)
+                stringify!(r#type)
             )
         );
     }
@@ -1136,113 +555,76 @@ mod test {
     }
 
     #[test]
-    fn bindgen_test_layout___wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t(
-    ) {
+    fn bindgen_test_layout___wasi_subscription_clock_t() {
         assert_eq!(
-            ::std::mem::size_of::<
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-            >(),
+            ::std::mem::size_of::<__wasi_subscription_clock_t>(),
             40usize,
-            concat!(
-                "Size of: ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                )
-            )
+            concat!("Size of: ", stringify!(__wasi_subscription_clock_t))
         );
         assert_eq!(
-            ::std::mem::align_of::<
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-            >(),
+            ::std::mem::align_of::<__wasi_subscription_clock_t>(),
             8usize,
-            concat!(
-                "Alignment of ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                )
-            )
+            concat!("Alignment of ", stringify!(__wasi_subscription_clock_t))
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-                >()))
-                .identifier as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_clock_t>())).identifier as *const _
+                    as usize
             },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                ),
+                stringify!(__wasi_subscription_clock_t),
                 "::",
                 stringify!(identifier)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-                >()))
-                .clock_id as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_clock_t>())).clock_id as *const _
+                    as usize
             },
             8usize,
             concat!(
                 "Offset of field: ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                ),
+                stringify!(__wasi_subscription_clock_t),
                 "::",
                 stringify!(clock_id)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-                >()))
-                .timeout as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_clock_t>())).timeout as *const _ as usize
             },
             16usize,
             concat!(
                 "Offset of field: ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                ),
+                stringify!(__wasi_subscription_clock_t),
                 "::",
                 stringify!(timeout)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-                >()))
-                .precision as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_clock_t>())).precision as *const _
+                    as usize
             },
             24usize,
             concat!(
                 "Offset of field: ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                ),
+                stringify!(__wasi_subscription_clock_t),
                 "::",
                 stringify!(precision)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t,
-                >()))
-                .flags as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_clock_t>())).flags as *const _ as usize
             },
             32usize,
             concat!(
                 "Offset of field: ",
-                stringify!(
-                    __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_clock_t
-                ),
+                stringify!(__wasi_subscription_clock_t),
                 "::",
                 stringify!(flags)
             )
@@ -1253,42 +635,27 @@ mod test {
     fn bindgen_test_layout___wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t(
     ) {
         assert_eq!(
-            ::std::mem::size_of::<
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t,
-            >(),
+            ::std::mem::size_of::<__wasi_subscription_fd_readwrite_t>(),
             4usize,
-            concat!(
-                "Size of: ",
-                stringify!(
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t
-            )
-            )
+            concat!("Size of: ", stringify!(__wasi_subscription_fd_readwrite_t))
         );
         assert_eq!(
-            ::std::mem::align_of::<
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t,
-            >(),
+            ::std::mem::align_of::<__wasi_subscription_fd_readwrite_t>(),
             4usize,
             concat!(
                 "Alignment of ",
-                stringify!(
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t
-            )
+                stringify!(__wasi_subscription_fd_readwrite_t)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t,
-            >()))
-            .fd as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_fd_readwrite_t>())).file_descriptor
+                    as *const _ as usize
             },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(
-                __wasi_subscription_t___wasi_subscription_u___wasi_subscription_u_fd_readwrite_t
-            ),
+                stringify!(__wasi_subscription_fd_readwrite_t),
                 "::",
                 stringify!(fd)
             )
@@ -1298,43 +665,33 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_subscription_t___wasi_subscription_u() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_subscription_t___wasi_subscription_u>(),
+            ::std::mem::size_of::<__wasi_subscription_u>(),
             40usize,
-            concat!(
-                "Size of: ",
-                stringify!(__wasi_subscription_t___wasi_subscription_u)
-            )
+            concat!("Size of: ", stringify!(__wasi_subscription_u))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_subscription_t___wasi_subscription_u>(),
+            ::std::mem::align_of::<__wasi_subscription_u>(),
             8usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_subscription_t___wasi_subscription_u)
-            )
+            concat!("Alignment of ", stringify!(__wasi_subscription_u))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_subscription_t___wasi_subscription_u>())).clock
-                    as *const _ as usize
-            },
+            unsafe { &(*(::std::ptr::null::<__wasi_subscription_u>())).clock as *const _ as usize },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_subscription_t___wasi_subscription_u),
+                stringify!(__wasi_subscription_u),
                 "::",
                 stringify!(clock)
             )
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<__wasi_subscription_t___wasi_subscription_u>())).fd_readwrite
-                    as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_subscription_u>())).fd_readwrite as *const _ as usize
             },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_subscription_t___wasi_subscription_u),
+                stringify!(__wasi_subscription_u),
                 "::",
                 stringify!(fd_readwrite)
             )
@@ -1366,13 +723,15 @@ mod test {
             )
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<__wasi_subscription_t>())).type_ as *const _ as usize },
+            unsafe {
+                &(*(::std::ptr::null::<__wasi_subscription_t>())).r#type as *const _ as usize
+            },
             8usize,
             concat!(
                 "Offset of field: ",
                 stringify!(__wasi_subscription_t),
                 "::",
-                stringify!(type_)
+                stringify!(r#type)
             )
         );
         assert_eq!(

--- a/src/wasi32.rs
+++ b/src/wasi32.rs
@@ -6,60 +6,14 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+use wig::witx_wasi32_types;
+
 use crate::wasi::*;
 
-// C types
-pub type long = i32;
-pub type ulong = u32;
+pub type uintptr_t = u32;
+pub type size_t = u32;
 
-// libc types
-pub type size_t = ulong;
-pub type intptr_t = long;
-pub type uintptr_t = ulong;
-pub type timer_t = uintptr_t; // *mut ::std::os::raw::c_void
-pub type caddr_t = uintptr_t; // *mut i8
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_ciovec_t {
-    pub buf: uintptr_t, // *const ::std::os::raw::c_void
-    pub buf_len: size_t,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_iovec_t {
-    pub buf: uintptr_t, // *mut ::std::os::raw::c_void
-    pub buf_len: size_t,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __wasi_prestat_t {
-    pub pr_type: __wasi_preopentype_t,
-    pub u: __wasi_prestat_t___wasi_prestat_u,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __wasi_prestat_t___wasi_prestat_u {
-    pub dir: __wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
-    pub pr_name_len: size_t,
-}
-
-pub const INTPTR_MIN: i32 = -2147483648;
-pub const INTPTR_MAX: u32 = 2147483647;
-pub const UINTPTR_MAX: u32 = 4294967295;
-pub const PTRDIFF_MIN: i32 = -2147483648;
-pub const PTRDIFF_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIZE_MAX: u32 = 4294967295;
+witx_wasi32_types!("unstable" "wasi_unstable_preview0");
 
 #[cfg(test)]
 mod test {
@@ -136,30 +90,23 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t>(),
+            ::std::mem::size_of::<__wasi_prestat_dir>(),
             4usize,
-            concat!(
-                "Size of: ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t)
-            )
+            concat!("Size of: ", stringify!(__wasi_prestat_dir))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t>(),
+            ::std::mem::align_of::<__wasi_prestat_dir>(),
             4usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t)
-            )
+            concat!("Alignment of ", stringify!(__wasi_prestat_dir))
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t>()))
-                    .pr_name_len as *const _ as usize
+                &(*(::std::ptr::null::<__wasi_prestat_dir>())).pr_name_len as *const _ as usize
             },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t),
+                stringify!(__wasi_prestat_dir),
                 "::",
                 stringify!(pr_name_len)
             )
@@ -169,27 +116,21 @@ mod test {
     #[test]
     fn bindgen_test_layout___wasi_prestat_t___wasi_prestat_u() {
         assert_eq!(
-            ::std::mem::size_of::<__wasi_prestat_t___wasi_prestat_u>(),
+            ::std::mem::size_of::<__wasi_prestat_u>(),
             4usize,
-            concat!("Size of: ", stringify!(__wasi_prestat_t___wasi_prestat_u))
+            concat!("Size of: ", stringify!(__wasi_prestat_u))
         );
         assert_eq!(
-            ::std::mem::align_of::<__wasi_prestat_t___wasi_prestat_u>(),
+            ::std::mem::align_of::<__wasi_prestat_u>(),
             4usize,
-            concat!(
-                "Alignment of ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u)
-            )
+            concat!("Alignment of ", stringify!(__wasi_prestat_u))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<__wasi_prestat_t___wasi_prestat_u>())).dir as *const _
-                    as usize
-            },
+            unsafe { &(*(::std::ptr::null::<__wasi_prestat_u>())).dir as *const _ as usize },
             0usize,
             concat!(
                 "Offset of field: ",
-                stringify!(__wasi_prestat_t___wasi_prestat_u),
+                stringify!(__wasi_prestat_u),
                 "::",
                 stringify!(dir)
             )

--- a/wig/Cargo.toml
+++ b/wig/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "wig"
+version = "0.0.0"
+authors = ["Dan Gohman <sunfish@mozilla.com>"]
+edition = "2018"
+categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
+license = "Apache-2.0 WITH LLVM-exception"
+repository = "https://github.com/CraneStation/wasi-common"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.2"
+proc-macro2 = "1.0.6"
+# We include the WASI repo primarily for the witx files, but it's also useful
+# to use the witx parser it contains, rather than the witx crate from
+# crates.io, so that it always matches the version of the witx files.
+witx = { path = "../WASI/tools/witx" }

--- a/wig/LICENSE
+++ b/wig/LICENSE
@@ -1,0 +1,220 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/wig/src/lib.rs
+++ b/wig/src/lib.rs
@@ -1,0 +1,34 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+extern crate quote;
+extern crate witx;
+
+mod raw_types;
+mod utils;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+
+#[proc_macro]
+pub fn witx_host_types(args: TokenStream) -> TokenStream {
+    TokenStream::from(raw_types::gen(
+        TokenStream2::from(args),
+        raw_types::Mode::Host,
+    ))
+}
+
+#[proc_macro]
+pub fn witx_wasi_types(args: TokenStream) -> TokenStream {
+    TokenStream::from(raw_types::gen(
+        TokenStream2::from(args),
+        raw_types::Mode::Wasi,
+    ))
+}
+
+#[proc_macro]
+pub fn witx_wasi32_types(args: TokenStream) -> TokenStream {
+    TokenStream::from(raw_types::gen(
+        TokenStream2::from(args),
+        raw_types::Mode::Wasi32,
+    ))
+}

--- a/wig/src/raw_types.rs
+++ b/wig/src/raw_types.rs
@@ -1,0 +1,250 @@
+//! Translate witx types to Rust.
+
+use crate::utils;
+use proc_macro2::{Delimiter, Group, Literal, TokenStream, TokenTree};
+use quote::{format_ident, quote};
+use std::convert::TryFrom;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Mode {
+    Host,
+    Wasi32,
+    Wasi,
+}
+
+impl Mode {
+    pub fn include_target_types(&self) -> bool {
+        match self {
+            Mode::Host | Mode::Wasi32 => true,
+            Mode::Wasi => false,
+        }
+    }
+}
+
+pub fn gen(args: TokenStream, mode: Mode) -> TokenStream {
+    let mut output = TokenStream::new();
+
+    let (path, _phase) = utils::witx_path_from_args(args);
+    let doc = match witx::load(&path) {
+        Ok(doc) => doc,
+        Err(e) => {
+            panic!("error opening file {}: {}", path, e);
+        }
+    };
+
+    gen_datatypes(&mut output, &doc, mode);
+
+    output
+}
+
+fn gen_datatypes(output: &mut TokenStream, doc: &witx::Document, mode: Mode) {
+    for datatype in doc.datatypes() {
+        if mode.include_target_types() != type_has_target_size(doc, &datatype) {
+            continue;
+        }
+
+        gen_datatype(output, doc, mode, &datatype);
+    }
+}
+
+fn gen_datatype(
+    output: &mut TokenStream,
+    doc: &witx::Document,
+    mode: Mode,
+    datatype: &witx::Datatype,
+) {
+    match &datatype.variant {
+        witx::DatatypeVariant::Alias(a) => {
+            if a.name.as_str() == "size_t" {
+                let wasi_name = format_ident!("__wasi_{}", a.name.as_str());
+                match mode {
+                    Mode::Host => output.extend(quote!(pub type #wasi_name = usize;)),
+                    Mode::Wasi => panic!("size_t has target-specific size"),
+                    Mode::Wasi32 => output.extend(quote!(pub type #wasi_name = u32;)),
+                }
+            } else {
+                let wasi_name = format_ident!("__wasi_{}", a.name.as_str());
+                let to = ident_tokens(mode, &a.to);
+                output.extend(quote!(pub type #wasi_name = #to;));
+            }
+        }
+        witx::DatatypeVariant::Enum(e) => {
+            let wasi_name = format_ident!("__wasi_{}", e.name.as_str());
+            let repr = int_repr_tokens(e.repr);
+            output.extend(quote!(pub type #wasi_name = #repr;));
+            for (index, variant) in e.variants.iter().enumerate() {
+                let value_name = format_ident!("__WASI_{}", variant.as_str());
+                let index_name = Literal::usize_unsuffixed(index);
+                output.extend(quote!(pub const #value_name: #wasi_name = #index_name;));
+            }
+        }
+        witx::DatatypeVariant::Flags(f) => {
+            let wasi_name = format_ident!("__wasi_{}", f.name.as_str());
+            let repr = int_repr_tokens(f.repr);
+            output.extend(quote!(pub type #wasi_name = #repr;));
+            for (index, flag) in f.flags.iter().enumerate() {
+                let value_name = format_ident!("__WASI_{}", flag.as_str());
+                let flag_value = Literal::u128_unsuffixed(
+                    1u128
+                        .checked_shl(u32::try_from(index).expect("flag value overflow"))
+                        .expect("flag value overflow"),
+                );
+                output.extend(quote!(pub const #value_name: #wasi_name = #flag_value;));
+            }
+        }
+        witx::DatatypeVariant::Struct(s) => {
+            output.extend(quote!(#[repr(C)]));
+
+            // Types which contain unions can't trivially implement Debug,
+            // Hash, or Eq, because the type itself doesn't record which
+            // union member is active.
+            if struct_has_union(&doc, s) {
+                output.extend(quote!(#[derive(Copy, Clone)]));
+                output.extend(quote!(#[allow(missing_debug_implementations)]));
+            } else {
+                output.extend(quote!(#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]));
+            }
+
+            let wasi_name = format_ident!("__wasi_{}", s.name.as_str());
+            output.extend(quote!(pub struct #wasi_name));
+
+            let mut inner = TokenStream::new();
+            for member in &s.members {
+                let member_name = format_ident!("r#{}", member.name.as_str());
+                let member_type = ident_tokens(mode, &member.type_);
+                inner.extend(quote!(pub #member_name: #member_type,));
+            }
+            let braced = Group::new(Delimiter::Brace, inner);
+            output.extend(TokenStream::from(TokenTree::Group(braced)));
+        }
+        witx::DatatypeVariant::Union(u) => {
+            output.extend(quote!(#[repr(C)]));
+            output.extend(quote!(#[derive(Copy, Clone)]));
+            output.extend(quote!(#[allow(missing_debug_implementations)]));
+
+            let wasi_name = format_ident!("__wasi_{}", u.name.as_str());
+            output.extend(quote!(pub union #wasi_name));
+
+            let mut inner = TokenStream::new();
+            for variant in &u.variants {
+                let variant_name = format_ident!("r#{}", variant.name.as_str());
+                let variant_type = ident_tokens(mode, &variant.type_);
+                inner.extend(quote!(pub #variant_name: #variant_type,));
+            }
+            let braced = Group::new(Delimiter::Brace, inner);
+            output.extend(TokenStream::from(TokenTree::Group(braced)));
+        }
+    }
+}
+
+fn int_repr_tokens(int_repr: witx::IntRepr) -> TokenStream {
+    match int_repr {
+        witx::IntRepr::U8 => quote!(u8),
+        witx::IntRepr::U16 => quote!(u16),
+        witx::IntRepr::U32 => quote!(u32),
+        witx::IntRepr::U64 => quote!(u64),
+    }
+}
+
+fn builtin_tokens(mode: Mode, builtin: witx::BuiltinType) -> TokenStream {
+    match builtin {
+        witx::BuiltinType::String => match mode {
+            Mode::Host => quote!((*const u8, usize)),
+            Mode::Wasi => panic!("strings have target-specific size"),
+            Mode::Wasi32 => quote!((u32, u32)),
+        },
+        witx::BuiltinType::U8 => quote!(u8),
+        witx::BuiltinType::U16 => quote!(u16),
+        witx::BuiltinType::U32 => quote!(u32),
+        witx::BuiltinType::U64 => quote!(u64),
+        witx::BuiltinType::S8 => quote!(i8),
+        witx::BuiltinType::S16 => quote!(i16),
+        witx::BuiltinType::S32 => quote!(i32),
+        witx::BuiltinType::S64 => quote!(i64),
+        witx::BuiltinType::F32 => quote!(f32),
+        witx::BuiltinType::F64 => quote!(f64),
+    }
+}
+
+fn ident_tokens(mode: Mode, ident: &witx::DatatypeIdent) -> TokenStream {
+    match ident {
+        witx::DatatypeIdent::Builtin(builtin) => builtin_tokens(mode, *builtin),
+        witx::DatatypeIdent::Ident(ident) => TokenStream::from(TokenTree::Ident(format_ident!(
+            "__wasi_{}",
+            ident.name.as_str()
+        ))),
+        witx::DatatypeIdent::Pointer(pointee) => {
+            let pointee = ident_tokens(mode, pointee);
+            match mode {
+                Mode::Host => quote!(*mut #pointee),
+                Mode::Wasi => panic!("pointers have target-specific size"),
+                Mode::Wasi32 => quote!(u32),
+            }
+        }
+        witx::DatatypeIdent::ConstPointer(pointee) => {
+            let pointee = ident_tokens(mode, pointee);
+            match mode {
+                Mode::Host => quote!(*const #pointee),
+                Mode::Wasi => panic!("pointers have target-specific size"),
+                Mode::Wasi32 => quote!(u32),
+            }
+        }
+        witx::DatatypeIdent::Array(element) => {
+            let element_name = ident_tokens(mode, element);
+            match mode {
+                Mode::Host => quote!((*const #element_name, usize)),
+                Mode::Wasi => panic!("arrays have target-specific size"),
+                Mode::Wasi32 => quote!((u32, u32)),
+            }
+        }
+    }
+}
+
+/// Test whether the given struct contains any union members.
+fn struct_has_union(doc: &witx::Document, s: &witx::StructDatatype) -> bool {
+    s.members.iter().any(|member| match &member.type_ {
+        witx::DatatypeIdent::Ident(ident) => match &doc.datatype(&ident.name).unwrap().variant {
+            witx::DatatypeVariant::Union(_) => true,
+            witx::DatatypeVariant::Struct(s) => struct_has_union(doc, &s),
+            _ => false,
+        },
+        _ => false,
+    })
+}
+
+/// Test whether the given type has a target-specific size.
+fn type_has_target_size(doc: &witx::Document, type_: &witx::Datatype) -> bool {
+    match &type_.variant {
+        witx::DatatypeVariant::Alias(a) => {
+            a.name.as_str() == "size_t" || ident_has_target_size(doc, &a.to)
+        }
+        witx::DatatypeVariant::Enum(_) => false,
+        witx::DatatypeVariant::Flags(_) => false,
+        witx::DatatypeVariant::Struct(s) => s
+            .members
+            .iter()
+            .any(|m| ident_has_target_size(doc, &m.type_)),
+        witx::DatatypeVariant::Union(u) => u
+            .variants
+            .iter()
+            .any(|v| ident_has_target_size(doc, &v.type_)),
+    }
+}
+
+/// Test whether the given type ident has a target-specific size.
+fn ident_has_target_size(doc: &witx::Document, ident: &witx::DatatypeIdent) -> bool {
+    match ident {
+        witx::DatatypeIdent::Ident(ident) => {
+            type_has_target_size(doc, &doc.datatype(&ident.name).unwrap())
+        }
+        witx::DatatypeIdent::Builtin(builtin) => {
+            if let witx::BuiltinType::String = builtin {
+                true
+            } else {
+                false
+            }
+        }
+        witx::DatatypeIdent::Pointer(_) | witx::DatatypeIdent::ConstPointer(_) => true,
+        witx::DatatypeIdent::Array(element) => ident_has_target_size(doc, element),
+    }
+}

--- a/wig/src/utils.rs
+++ b/wig/src/utils.rs
@@ -1,0 +1,54 @@
+use proc_macro2::{Literal, TokenStream, TokenTree};
+/// Given the input tokens to a macro invocation, return the path to the
+/// witx file to process.
+pub(crate) fn witx_path_from_args(args: TokenStream) -> (String, String) {
+    let mut strings = Vec::new();
+
+    for arg in args {
+        if let TokenTree::Literal(literal) = arg {
+            let parsed = parse_string_literal(literal);
+
+            strings.push(parsed);
+        } else {
+            panic!("arguments must be string literals");
+        }
+    }
+
+    if strings.len() != 2 {
+        panic!("expected two string literals");
+    }
+
+    let phase = &strings[0];
+    let id = &strings[1];
+    let path = witx_path(phase, id);
+
+    (path, phase.clone())
+}
+
+fn witx_path(phase: &str, id: &str) -> String {
+    let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".into());
+    format!("{}/WASI/phases/{}/witx/{}.witx", root, phase, id)
+}
+
+// Convert a `Literal` holding a string literal into the `String`.
+//
+// FIXME: It feels like there should be an easier way to do this.
+fn parse_string_literal(literal: Literal) -> String {
+    let s = literal.to_string();
+    assert!(
+        s.starts_with('"') && s.ends_with('"'),
+        "string literal must be enclosed in double-quotes"
+    );
+
+    let trimmed = s[1..s.len() - 1].to_owned();
+    assert!(
+        !trimmed.contains('"'),
+        "string literal must not contain embedded quotes for now"
+    );
+    assert!(
+        !trimmed.contains('\\'),
+        "string literal must not contain embedded backslashes for now"
+    );
+
+    trimmed
+}


### PR DESCRIPTION
This is based on #151 and is somewhat experimental. It also depends on at least https://github.com/WebAssembly/WASI/pull/129.

Use the witx API descriptions to generate the bulk of the contents of
host.rs, wasi.rs, and wasi32.rs.
    
This also prunes out many of the miscellaneous libc definitions from
those files which aren't currently in use by wasi-common. If there's
anything removed that's still needed by someone, it's easy to add things
back in.
