### PR TITLE
Fixes path_symlink_trailing_slashes on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -200,7 +200,6 @@ mod wasm_tests {
                         "truncation_rights" => true,
                         "fd_readdir" => true,
                         "path_rename_trailing_slashes" => true,
-                        "path_symlink_trailing_slashes" => true,
                         _ => false,
                     }
                 } else {

--- a/src/sys/windows/host_impl.rs
+++ b/src/sys/windows/host_impl.rs
@@ -22,7 +22,7 @@ pub(crate) fn errno_from_win(error: winx::winerror::WinError) -> host::__wasi_er
         ERROR_SHARING_VIOLATION => host::__WASI_EACCES,
         ERROR_PRIVILEGE_NOT_HELD => host::__WASI_ENOTCAPABLE, // TODO is this the correct mapping?
         ERROR_INVALID_HANDLE => host::__WASI_EBADF,
-        ERROR_INVALID_NAME => host::__WASI_EINVAL,
+        ERROR_INVALID_NAME => host::__WASI_ENOENT,
         ERROR_NOT_ENOUGH_MEMORY => host::__WASI_ENOMEM,
         ERROR_OUTOFMEMORY => host::__WASI_ENOMEM,
         ERROR_DIR_NOT_EMPTY => host::__WASI_ENOTEMPTY,
@@ -35,6 +35,7 @@ pub(crate) fn errno_from_win(error: winx::winerror::WinError) -> host::__wasi_er
         ERROR_NOT_A_REPARSE_POINT => host::__WASI_EINVAL,
         ERROR_NEGATIVE_SEEK => host::__WASI_EINVAL,
         ERROR_DIRECTORY => host::__WASI_ENOTDIR,
+        ERROR_ALREADY_EXISTS => host::__WASI_EEXIST,
         _ => host::__WASI_ENOTSUP,
     }
 }

--- a/winx/src/winerror.rs
+++ b/winx/src/winerror.rs
@@ -86,6 +86,8 @@ win_error_expand! {
     ERROR_NEGATIVE_SEEK,
     /// The directory name is invalid.
     ERROR_DIRECTORY,
+    /// Cannot create a file when that file already exists.
+    ERROR_ALREADY_EXISTS,
 }
 
 impl WinError {


### PR DESCRIPTION
This commit:
* adds missing `ERROR_ALREADY_EXISTS => __WASI_EEXIST` mapping
* re-routes Win errors into correct WASI values in `symlink_*`
  fns when target exists and/or contains a trailing slash
* remaps `ERROR_INVALID_NAME => __WASI_ENOENT`