### PR TITLE
Implement a helper for converting &str to CString.

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Result};
 use std::convert::TryInto;
+use std::ffi::CString;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) fn systemtime_to_timestamp(st: SystemTime) -> Result<u64> {
@@ -8,4 +9,8 @@ pub(crate) fn systemtime_to_timestamp(st: SystemTime) -> Result<u64> {
         .as_nanos()
         .try_into()
         .map_err(Into::into) // u128 doesn't fit into u64
+}
+
+pub(crate) fn str_to_cstring(s: &str) -> Result<CString> {
+    CString::new(s.as_bytes()).map_err(|_| Error::EILSEQ)
 }

--- a/src/hostcalls_impl/fs_helpers.rs
+++ b/src/hostcalls_impl/fs_helpers.rs
@@ -1,7 +1,9 @@
 #![allow(non_camel_case_types)]
+use crate::helpers::str_to_cstring;
 use crate::sys::host_impl;
 use crate::sys::hostcalls_impl::fs_helpers::*;
 use crate::{host, Error, Result};
+use std::ffi::CString;
 use std::fs::File;
 use std::path::{Component, Path};
 
@@ -18,6 +20,10 @@ impl PathGet {
 
     pub(crate) fn path(&self) -> &str {
         &self.path
+    }
+
+    pub(crate) fn path_cstring(&self) -> Result<CString> {
+        str_to_cstring(&self.path)
     }
 }
 

--- a/src/sys/unix/linux/hostcalls_impl.rs
+++ b/src/sys/unix/linux/hostcalls_impl.rs
@@ -1,4 +1,5 @@
 use super::osfile::OsFile;
+use crate::helpers::str_to_cstring;
 use crate::hostcalls_impl::PathGet;
 use crate::sys::host_impl;
 use crate::{host, Error, Result};
@@ -13,7 +14,7 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
     use nix::errno;
     use nix::libc::unlinkat;
 
-    let path_cstr = CString::new(resolved.path().as_bytes()).map_err(|_| Error::EILSEQ)?;
+    let path_cstr = resolved.path_cstring()?;
 
     // nix doesn't expose unlinkat() yet
     let res = unsafe { unlinkat(resolved.dirfd().as_raw_fd(), path_cstr.as_ptr(), 0) };
@@ -27,8 +28,8 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
 pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
     use nix::{errno::Errno, libc::symlinkat};
 
-    let old_path_cstr = CString::new(old_path.as_bytes()).map_err(|_| Error::EILSEQ)?;
-    let new_path_cstr = CString::new(resolved.path().as_bytes()).map_err(|_| Error::EILSEQ)?;
+    let old_path_cstr = str_to_cstring(old_path)?;
+    let new_path_cstr = resolved.path_cstring()?;
 
     log::debug!("path_symlink old_path = {:?}", old_path);
     log::debug!("path_symlink resolved = {:?}", resolved);
@@ -49,8 +50,8 @@ pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
 
 pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> Result<()> {
     use nix::libc::renameat;
-    let old_path_cstr = CString::new(resolved_old.path().as_bytes()).map_err(|_| Error::EILSEQ)?;
-    let new_path_cstr = CString::new(resolved_new.path().as_bytes()).map_err(|_| Error::EILSEQ)?;
+    let old_path_cstr = resolved_old.path_cstring()?;
+    let new_path_cstr = resolved_new.path_cstring()?;
 
     let res = unsafe {
         renameat(

--- a/src/sys/windows/hostcalls_impl/misc.rs
+++ b/src/sys/windows/hostcalls_impl/misc.rs
@@ -14,7 +14,6 @@ lazy_static! {
     static ref START_MONOTONIC: Instant = Instant::now();
 }
 
-
 pub(crate) fn clock_res_get(clock_id: host::__wasi_clockid_t) -> Result<host::__wasi_timestamp_t> {
     unimplemented!("clock_res_get")
 }


### PR DESCRIPTION
This commit implements a simple helper for converting `&str` to `CString` and
mapping to the appropriate WASI error.

It also adds a `to_cstring` helper method in `PathGet` where the conversion was
used the most.

Fixes #104.