### PR TITLE
Check for overflow when incrementing the `preopen_fd` counter.

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -135,7 +135,7 @@ impl WasiCtxBuilder {
             let mut fe = FdEntry::from(dir)?;
             fe.preopen_path = Some(guest_path);
             self.fds.insert(preopen_fd, fe);
-            preopen_fd += 1;
+            preopen_fd = preopen_fd.checked_add(1).ok_or(Error::ENFILE)?;
         }
 
         let env = self


### PR DESCRIPTION
If someone somehow defines more preopens than can fit in the
`__wasi_fd_t` index space, we should detect it instead of silently
wrapping around.