### PR TITLE
Fix path_get returning ENOTDIR when base not dir

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -188,63 +188,13 @@ impl WasiCtx {
         self.fds.contains_key(&fd)
     }
 
-    /// Get an immutable `FdEntry` corresponding to the specified raw WASI `fd` with
-    /// rights automatically validated.
-    ///
-    /// If you want to extract the `FdEntry` without validating the rights
-    /// at this stage, use `get_nonvalidated_fd_entry` instead.
-    pub(crate) unsafe fn get_fd_entry(
-        &self,
-        fd: host::__wasi_fd_t,
-        rights_base: host::__wasi_rights_t,
-        rights_inheriting: host::__wasi_rights_t,
-    ) -> Result<&FdEntry> {
-        if let Some(fe) = self.fds.get(&fd) {
-            fe.validate_rights(rights_base, rights_inheriting)?;
-            Ok(fe)
-        } else {
-            Err(Error::EBADF)
-        }
-    }
-
-    /// Get an immutable `FdEntry` corresponding to the specified raw WASI `fd` without
-    /// rights automatically validated.
-    ///
-    /// It is important to call `FdEntry::validate_rights` before extracting the underlying
-    /// `Descriptor` from the `FdEntry`.
-    pub(crate) unsafe fn get_nonvalidated_fd_entry(
-        &self,
-        fd: host::__wasi_fd_t,
-    ) -> Result<&FdEntry> {
+    /// Get an immutable `FdEntry` corresponding to the specified raw WASI `fd`.
+    pub(crate) unsafe fn get_fd_entry(&self, fd: host::__wasi_fd_t) -> Result<&FdEntry> {
         self.fds.get(&fd).ok_or(Error::EBADF)
     }
 
-    /// Get a mutable `FdEntry` corresponding to the specified raw WASI `fd` with
-    /// rights automatically validated.
-    ///
-    /// If you want to extract the `FdEntry` without validating the rights
-    /// at this stage, use `get_nonvalidated_fd_entry_mut` instead.
+    /// Get a mutable `FdEntry` corresponding to the specified raw WASI `fd`.
     pub(crate) unsafe fn get_fd_entry_mut(
-        &mut self,
-        fd: host::__wasi_fd_t,
-        rights_base: host::__wasi_rights_t,
-        rights_inheriting: host::__wasi_rights_t,
-    ) -> Result<&mut FdEntry> {
-        if let Some(fe) = self.fds.get_mut(&fd) {
-            fe.validate_rights(rights_base, rights_inheriting)?;
-            Ok(fe)
-        } else {
-            Err(Error::EBADF)
-        }
-    }
-
-    /// Get a mutable `FdEntry` corresponding to the specified raw WASI `fd` without
-    /// rights automatically validated.
-    ///
-    /// It is important to call `FdEntry::validate_rights` before extracting the underlying
-    /// `Descriptor` from the `FdEntry`.
-    #[allow(dead_code)]
-    pub(crate) unsafe fn get_nonvalidated_fd_entry_mut(
         &mut self,
         fd: host::__wasi_fd_t,
     ) -> Result<&mut FdEntry> {

--- a/src/fdentry.rs
+++ b/src/fdentry.rs
@@ -133,4 +133,17 @@ impl FdEntry {
             },
         )
     }
+
+    pub(crate) fn validate_rights(
+        &self,
+        rights_base: host::__wasi_rights_t,
+        rights_inheriting: host::__wasi_rights_t,
+    ) -> Result<&Self> {
+        if !self.rights_base & rights_base != 0 || !self.rights_inheriting & rights_inheriting != 0
+        {
+            Err(Error::ENOTCAPABLE)
+        } else {
+            Ok(&self)
+        }
+    }
 }

--- a/src/hostcalls_impl/fs.rs
+++ b/src/hostcalls_impl/fs.rs
@@ -33,8 +33,9 @@ pub(crate) unsafe fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) ->
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_DATASYNC, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_DATASYNC, 0)?
+        .as_file()?;
 
     fd.sync_data().map_err(Into::into)
 }
@@ -59,8 +60,9 @@ pub(crate) unsafe fn fd_pread(
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_READ, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_READ, 0)?
+        .as_file()?;
 
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
 
@@ -109,8 +111,9 @@ pub(crate) unsafe fn fd_pwrite(
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_READ, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_READ, 0)?
+        .as_file()?;
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
 
     let offset = dec_filesize(offset);
@@ -148,15 +151,17 @@ pub(crate) unsafe fn fd_read(
         nread
     );
 
-    let fd = dec_fd(fd);
     let mut iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
-    let fe = wasi_ctx.get_fd_entry_mut(fd, host::__WASI_RIGHT_FD_READ, 0)?;
     let mut iovs: Vec<io::IoSliceMut> = iovs
         .iter_mut()
         .map(|vec| host::iovec_to_host_mut(vec))
         .collect();
+    let fd = dec_fd(fd);
 
-    let maybe_host_nread = match &mut fe.fd_object.descriptor {
+    let maybe_host_nread = match wasi_ctx
+        .get_fd_entry_mut(fd)?
+        .as_descriptor_mut(host::__WASI_RIGHT_FD_READ, 0)?
+    {
         Descriptor::OsFile(file) => file.read_vectored(&mut iovs),
         Descriptor::Stdin => io::stdin().lock().read_vectored(&mut iovs),
         _ => return Err(Error::EBADF),
@@ -183,27 +188,28 @@ pub(crate) unsafe fn fd_renumber(
         return Err(Error::EBADF);
     }
 
+    let from_fe = wasi_ctx.get_fd_entry(from)?;
+    let to_fe = wasi_ctx.get_fd_entry(to)?;
+
     // Don't allow renumbering over a pre-opened resource.
     // TODO: Eventually, we do want to permit this, once libpreopen in
     // userspace is capable of removing entries from its tables as well.
-    if wasi_ctx.fds[&from].preopen_path.is_some() || wasi_ctx.fds[&to].preopen_path.is_some() {
+    if from_fe.preopen_path.is_some() || to_fe.preopen_path.is_some() {
         return Err(Error::ENOTSUP);
     }
 
     // check if stdio fds
     // TODO should we renumber stdio fds?
-    if !wasi_ctx.fds[&from].fd_object.descriptor.is_file()
-        || !wasi_ctx.fds[&to].fd_object.descriptor.is_file()
-    {
+    if !from_fe.as_descriptor(0, 0)?.is_file() || !to_fe.as_descriptor(0, 0)?.is_file() {
         return Err(Error::EBADF);
     }
 
-    let fe_from_dup = wasi_ctx.fds[&from]
-        .fd_object
-        .descriptor
+    let fe_from_dup = from_fe
+        .as_descriptor(0, 0)?
         .as_file()
         .and_then(|file| FdEntry::duplicate(file))?;
 
+    // TODO clean this up
     wasi_ctx.fds.insert(to, fe_from_dup);
     wasi_ctx.fds.remove(&from);
 
@@ -236,8 +242,9 @@ pub(crate) unsafe fn fd_seek(
         host::__WASI_RIGHT_FD_SEEK | host::__WASI_RIGHT_FD_TELL
     };
     let fd = wasi_ctx
-        .get_fd_entry_mut(fd, rights, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file_mut())?;
+        .get_fd_entry_mut(fd)?
+        .as_descriptor_mut(rights, 0)?
+        .as_file_mut()?;
 
     let pos = match whence {
         host::__WASI_WHENCE_CUR => SeekFrom::Current(offset),
@@ -262,8 +269,9 @@ pub(crate) unsafe fn fd_tell(
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry_mut(fd, host::__WASI_RIGHT_FD_TELL, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file_mut())?;
+        .get_fd_entry_mut(fd)?
+        .as_descriptor_mut(host::__WASI_RIGHT_FD_TELL, 0)?
+        .as_file_mut()?;
 
     let host_offset = fd.seek(SeekFrom::Current(0))?;
 
@@ -282,12 +290,12 @@ pub(crate) unsafe fn fd_fdstat_get(
 
     let mut fdstat = dec_fdstat_byref(memory, fdstat_ptr)?;
     let fd = dec_fd(fd);
-    let fe = wasi_ctx.get_fd_entry(fd, 0, 0)?;
-    let fd = fe.fd_object.descriptor.as_file()?;
+    let wasi_fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
 
-    let fs_flags = hostcalls_impl::fd_fdstat_get(fd)?;
+    let fs_flags = hostcalls_impl::fd_fdstat_get(wasi_fd)?;
 
-    fdstat.fs_filetype = fe.fd_object.file_type;
+    let fe = wasi_ctx.get_fd_entry(fd)?;
+    fdstat.fs_filetype = fe.file_type;
     fdstat.fs_rights_base = fe.rights_base;
     fdstat.fs_rights_inheriting = fe.rights_inheriting;
     fdstat.fs_flags = fs_flags;
@@ -306,9 +314,7 @@ pub(crate) unsafe fn fd_fdstat_set_flags(
 
     let fdflags = dec_fdflags(fdflags);
     let fd = dec_fd(fd);
-    let fd = wasi_ctx
-        .get_fd_entry(fd, 0, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
 
     hostcalls_impl::fd_fdstat_set_flags(fd, fdflags)
 }
@@ -327,7 +333,7 @@ pub(crate) unsafe fn fd_fdstat_set_rights(
     );
 
     let fd = dec_fd(fd);
-    let fe = wasi_ctx.fds.get_mut(&fd).ok_or(Error::EBADF)?;
+    let fe = &mut wasi_ctx.get_fd_entry_mut(fd)?;
 
     if fe.rights_base & fs_rights_base != fs_rights_base
         || fe.rights_inheriting & fs_rights_inheriting != fs_rights_inheriting
@@ -345,8 +351,9 @@ pub(crate) unsafe fn fd_sync(wasi_ctx: &WasiCtx, fd: wasm32::__wasi_fd_t) -> Res
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_SYNC, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_SYNC, 0)?
+        .as_file()?;
     fd.sync_all().map_err(Into::into)
 }
 
@@ -368,11 +375,13 @@ pub(crate) unsafe fn fd_write(
 
     let fd = dec_fd(fd);
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
-    let fe = wasi_ctx.get_fd_entry_mut(fd, host::__WASI_RIGHT_FD_WRITE, 0)?;
     let iovs: Vec<io::IoSlice> = iovs.iter().map(|vec| host::iovec_to_host(vec)).collect();
 
     // perform unbuffered writes
-    let host_nwritten = match &mut fe.fd_object.descriptor {
+    let host_nwritten = match wasi_ctx
+        .get_fd_entry_mut(fd)?
+        .as_descriptor_mut(host::__WASI_RIGHT_FD_WRITE, 0)?
+    {
         Descriptor::OsFile(file) => file.write_vectored(&iovs)?,
         Descriptor::Stdin => return Err(Error::EBADF),
         Descriptor::Stdout => {
@@ -411,8 +420,9 @@ pub(crate) unsafe fn fd_advise(
     let offset = dec_filesize(offset);
     let len = dec_filesize(len);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_ADVISE, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_ADVISE, 0)?
+        .as_file()?;
 
     hostcalls_impl::fd_advise(fd, advice, offset, len)
 }
@@ -429,8 +439,9 @@ pub(crate) unsafe fn fd_allocate(
     let offset = dec_filesize(offset);
     let len = dec_filesize(len);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_ALLOCATE, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_ALLOCATE, 0)?
+        .as_file()?;
 
     let metadata = fd.metadata()?;
 
@@ -468,7 +479,7 @@ pub(crate) unsafe fn path_create_directory(
     trace!("     | (path_ptr,path_len)='{}'", path);
 
     let rights = host::__WASI_RIGHT_PATH_OPEN | host::__WASI_RIGHT_PATH_CREATE_DIRECTORY;
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(fe, rights, 0, 0, path, false)?;
 
     hostcalls_impl::path_create_directory(resolved)
@@ -506,8 +517,8 @@ pub(crate) unsafe fn path_link(
     trace!("     | (old_path_ptr,old_path_len)='{}'", old_path);
     trace!("     | (new_path_ptr,new_path_len)='{}'", new_path);
 
-    let old_fe = &wasi_ctx.get_nonvalidated_fd_entry(old_dirfd)?;
-    let new_fe = &wasi_ctx.get_nonvalidated_fd_entry(new_dirfd)?;
+    let old_fe = &wasi_ctx.get_fd_entry(old_dirfd)?;
+    let new_fe = &wasi_ctx.get_fd_entry(new_dirfd)?;
     let resolved_old = path_get(
         old_fe,
         host::__WASI_RIGHT_PATH_LINK_SOURCE,
@@ -570,7 +581,7 @@ pub(crate) unsafe fn path_open(
 
     let (needed_base, needed_inheriting) =
         path_open_rights(fs_rights_base, fs_rights_inheriting, oflags, fs_flags);
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(
         fe,
         needed_base,
@@ -625,8 +636,9 @@ pub(crate) unsafe fn fd_readdir(
 
     let fd = dec_fd(fd);
     let file = wasi_ctx
-        .get_fd_entry_mut(fd, host::__WASI_RIGHT_FD_READDIR, 0)
-        .and_then(|entry| entry.fd_object.descriptor.as_file_mut())?;
+        .get_fd_entry_mut(fd)?
+        .as_descriptor_mut(host::__WASI_RIGHT_FD_READDIR, 0)?
+        .as_file_mut()?;
     let host_buf = dec_slice_of_mut::<u8>(memory, buf, buf_len)?;
 
     trace!("     | (buf,buf_len)={:?}", host_buf);
@@ -667,7 +679,7 @@ pub(crate) unsafe fn path_readlink(
 
     trace!("     | (path_ptr,path_len)='{}'", &path);
 
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(fe, host::__WASI_RIGHT_PATH_READLINK, 0, 0, &path, false)?;
 
     let mut buf = dec_slice_of_mut::<u8>(memory, buf_ptr, buf_len)?;
@@ -710,8 +722,8 @@ pub(crate) unsafe fn path_rename(
     trace!("     | (old_path_ptr,old_path_len)='{}'", old_path);
     trace!("     | (new_path_ptr,new_path_len)='{}'", new_path);
 
-    let old_fe = &wasi_ctx.get_nonvalidated_fd_entry(old_dirfd)?;
-    let new_fe = &wasi_ctx.get_nonvalidated_fd_entry(new_dirfd)?;
+    let old_fe = &wasi_ctx.get_fd_entry(old_dirfd)?;
+    let new_fe = &wasi_ctx.get_fd_entry(new_dirfd)?;
     let resolved_old = path_get(
         old_fe,
         host::__WASI_RIGHT_PATH_RENAME_SOURCE,
@@ -748,9 +760,7 @@ pub(crate) unsafe fn fd_filestat_get(
     );
 
     let fd = dec_fd(fd);
-    let fd = wasi_ctx
-        .get_fd_entry(fd, 0, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
 
     let host_filestat = hostcalls_impl::fd_filestat_get_impl(fd)?;
 
@@ -776,8 +786,9 @@ pub(crate) unsafe fn fd_filestat_set_times(
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_FILESTAT_SET_TIMES, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_FILESTAT_SET_TIMES, 0)?
+        .as_file()?;
 
     let st_atim = dec_timestamp(st_atim);
     let st_mtim = dec_timestamp(st_mtim);
@@ -831,8 +842,9 @@ pub(crate) unsafe fn fd_filestat_set_size(
 
     let fd = dec_fd(fd);
     let fd = wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_FD_FILESTAT_SET_SIZE, 0)
-        .and_then(|fe| fe.fd_object.descriptor.as_file())?;
+        .get_fd_entry(fd)?
+        .as_descriptor(host::__WASI_RIGHT_FD_FILESTAT_SET_SIZE, 0)?
+        .as_file()?;
 
     let st_size = dec_filesize(st_size);
     // This check will be unnecessary when rust-lang/rust#63326 is fixed
@@ -866,7 +878,7 @@ pub(crate) unsafe fn path_filestat_get(
 
     trace!("     | (path_ptr,path_len)='{}'", path);
 
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(
         fe,
         host::__WASI_RIGHT_PATH_FILESTAT_GET,
@@ -913,7 +925,7 @@ pub(crate) unsafe fn path_filestat_set_times(
     let st_mtim = dec_timestamp(st_mtim);
     let fst_flags = dec_fstflags(fst_flags);
 
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(
         fe,
         host::__WASI_RIGHT_PATH_FILESTAT_SET_TIMES,
@@ -953,7 +965,7 @@ pub(crate) unsafe fn path_symlink(
     trace!("     | (old_path_ptr,old_path_len)='{}'", old_path);
     trace!("     | (new_path_ptr,new_path_len)='{}'", new_path);
 
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved_new = path_get(fe, host::__WASI_RIGHT_PATH_SYMLINK, 0, 0, new_path, true)?;
 
     hostcalls_impl::path_symlink(old_path, resolved_new)
@@ -978,7 +990,7 @@ pub(crate) unsafe fn path_unlink_file(
 
     trace!("     | (path_ptr,path_len)='{}'", path);
 
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(fe, host::__WASI_RIGHT_PATH_UNLINK_FILE, 0, 0, path, false)?;
 
     hostcalls_impl::path_unlink_file(resolved)
@@ -1003,7 +1015,7 @@ pub(crate) unsafe fn path_remove_directory(
 
     trace!("     | (path_ptr,path_len)='{}'", path);
 
-    let fe = &wasi_ctx.get_nonvalidated_fd_entry(dirfd)?;
+    let fe = &wasi_ctx.get_fd_entry(dirfd)?;
     let resolved = path_get(
         fe,
         host::__WASI_RIGHT_PATH_REMOVE_DIRECTORY,
@@ -1031,30 +1043,27 @@ pub(crate) unsafe fn fd_prestat_get(
     );
 
     let fd = dec_fd(fd);
-    // TODO: is this the correct right for this?
-    wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_PATH_OPEN, 0)
-        .and_then(|fe| {
-            let po_path = fe.preopen_path.as_ref().ok_or(Error::ENOTSUP)?;
-            if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
-                return Err(Error::ENOTDIR);
-            }
+    // TODO: should we validate any rights here?
+    let fe = &wasi_ctx.get_fd_entry(fd)?;
+    let po_path = fe.preopen_path.as_ref().ok_or(Error::ENOTSUP)?;
+    if fe.file_type != host::__WASI_FILETYPE_DIRECTORY {
+        return Err(Error::ENOTDIR);
+    }
 
-            let path = host_impl::path_from_host(po_path.as_os_str())?;
+    let path = host_impl::path_from_host(po_path.as_os_str())?;
 
-            enc_prestat_byref(
-                memory,
-                prestat_ptr,
-                host::__wasi_prestat_t {
-                    pr_type: host::__WASI_PREOPENTYPE_DIR,
-                    u: host::__wasi_prestat_t___wasi_prestat_u {
-                        dir: host::__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
-                            pr_name_len: path.len(),
-                        },
-                    },
+    enc_prestat_byref(
+        memory,
+        prestat_ptr,
+        host::__wasi_prestat_t {
+            pr_type: host::__WASI_PREOPENTYPE_DIR,
+            u: host::__wasi_prestat_t___wasi_prestat_u {
+                dir: host::__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
+                    pr_name_len: path.len(),
                 },
-            )
-        })
+            },
+        },
+    )
 }
 
 pub(crate) unsafe fn fd_prestat_dir_name(
@@ -1072,25 +1081,22 @@ pub(crate) unsafe fn fd_prestat_dir_name(
     );
 
     let fd = dec_fd(fd);
+    // TODO: should we validate any rights here?
+    let fe = &wasi_ctx.get_fd_entry(fd)?;
+    let po_path = fe.preopen_path.as_ref().ok_or(Error::ENOTSUP)?;
+    if fe.file_type != host::__WASI_FILETYPE_DIRECTORY {
+        return Err(Error::ENOTDIR);
+    }
 
-    wasi_ctx
-        .get_fd_entry(fd, host::__WASI_RIGHT_PATH_OPEN, 0)
-        .and_then(|fe| {
-            let po_path = fe.preopen_path.as_ref().ok_or(Error::ENOTSUP)?;
-            if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
-                return Err(Error::ENOTDIR);
-            }
+    let path = host_impl::path_from_host(po_path.as_os_str())?;
 
-            let path = host_impl::path_from_host(po_path.as_os_str())?;
+    if path.len() > dec_usize(path_len) {
+        return Err(Error::ENAMETOOLONG);
+    }
 
-            if path.len() > dec_usize(path_len) {
-                return Err(Error::ENAMETOOLONG);
-            }
+    trace!("     | (path_ptr,path_len)='{}'", path);
 
-            trace!("     | (path_ptr,path_len)='{}'", path);
-
-            enc_slice_of(memory, path.as_bytes(), path_ptr)
-        })
+    enc_slice_of(memory, path.as_bytes(), path_ptr)
 }
 
 #[allow(dead_code)] // trouble with sockets

--- a/src/hostcalls_impl/fs_helpers.rs
+++ b/src/hostcalls_impl/fs_helpers.rs
@@ -2,7 +2,7 @@
 use crate::helpers::str_to_cstring;
 use crate::sys::host_impl;
 use crate::sys::hostcalls_impl::fs_helpers::*;
-use crate::{fdentry::FdObject, host, Error, Result};
+use crate::{fdentry::FdEntry, host, Error, Result};
 use std::ffi::CString;
 use std::fs::File;
 use std::path::{Component, Path};
@@ -31,7 +31,9 @@ impl PathGet {
 ///
 /// This is a workaround for not having Capsicum support in the OS.
 pub(crate) fn path_get(
-    fo: &FdObject,
+    fe: &FdEntry,
+    rights_base: host::__wasi_rights_t,
+    rights_inheriting: host::__wasi_rights_t,
     dirflags: host::__wasi_lookupflags_t,
     path: &str,
     needs_final_component: bool,
@@ -43,12 +45,17 @@ pub(crate) fn path_get(
         return Err(Error::EILSEQ);
     }
 
-    if fo.file_type != host::__WASI_FILETYPE_DIRECTORY {
+    if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
         // if `dirfd` doesn't refer to a directory, return `ENOTDIR`.
         return Err(Error::ENOTDIR);
     }
 
-    let dirfd = fo.descriptor.as_file()?.try_clone()?;
+    let dirfd = fe
+        .validate_rights(rights_base, rights_inheriting)?
+        .fd_object
+        .descriptor
+        .as_file()?
+        .try_clone()?;
 
     // Stack of directory file descriptors. Index 0 always corresponds with the directory provided
     // to this function. Entering a directory causes a file descriptor to be pushed, while handling

--- a/src/hostcalls_impl/fs_helpers.rs
+++ b/src/hostcalls_impl/fs_helpers.rs
@@ -45,15 +45,13 @@ pub(crate) fn path_get(
         return Err(Error::EILSEQ);
     }
 
-    if fe.fd_object.file_type != host::__WASI_FILETYPE_DIRECTORY {
+    if fe.file_type != host::__WASI_FILETYPE_DIRECTORY {
         // if `dirfd` doesn't refer to a directory, return `ENOTDIR`.
         return Err(Error::ENOTDIR);
     }
 
     let dirfd = fe
-        .validate_rights(rights_base, rights_inheriting)?
-        .fd_object
-        .descriptor
+        .as_descriptor(rights_base, rights_inheriting)?
         .as_file()?
         .try_clone()?;
 

--- a/src/hostcalls_impl/misc.rs
+++ b/src/hostcalls_impl/misc.rs
@@ -255,8 +255,8 @@ pub(crate) fn poll_oneoff(
 
                 match unsafe {
                     wasi_ctx
-                        .get_fd_entry(wasi_fd, rights, 0)
-                        .map(|fe| &fe.fd_object.descriptor)
+                        .get_fd_entry(wasi_fd)
+                        .and_then(|fe| fe.as_descriptor(rights, 0))
                 } {
                     Ok(descriptor) => fd_events.push(FdEventData {
                         descriptor,
@@ -281,7 +281,7 @@ pub(crate) fn poll_oneoff(
                             enc_event(event);
                         events_count += 1;
                     }
-                }
+                };
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
~~This commit makes certain adjustments to `WasiCtx` and `FdEntry` by introducing methods `get_nonvalidated_fd_entry` and `get_nonvalidated_fd_entry_mut` which only check if the `FdEntry` corresponding to the specified raw WASI fd exists in the context object but **without** automatically validating the rights. Thanks to postponing the validation until after the `FdEntry` object is extracted from the context, it is possible to check if the extracted `FdEntry` object is indeed a valid dir descriptor when processing paths in `path_get` helper fn. In essence then, this commit closes #158.~~

~~I've made this PR a draft, so that we can get some discussion going before it's ready for merging into the upstream (if at all). One thing I really don't like about the proposed changes in this PR, is the fact that using `get_nonvalidated_fd_entry` requires the caller to remember to call `FdEntry::validate_rights` manually at a later time instant. We currently do not have a mechanism which would enforce this which can potentially lead to certain nasty security bugs such as operating on an fd which doesn't possess the required rights and yet it's fine since we have used `get_nonvalidated_fd_entry` and forgot to call `FdEntry::validate_rights`. I'd really like to circumvent this potential issue *before* we go ahead and merge this (if at all).~~

~~Also, just so that it's clear, this PR already includes a test case for the behaviour specified in #155. (The source code for the test case can be found here CraneStation/wasi-misc-tests#41.)~~

This PR reshuffles a few things in the internals of `WasiCtx` and `FdEntry`. This serves the purpose of correctly facilitating the proposed behaviour in #155, and, in the process, hopefully, uncluttering some bits of code while advocating safe usage of the introduced abstractions.

The changes:
* remove `FdObject` and flatten its contents into `FdEntry`
* accessing `FdEntry`s from `WasiCtx` context object checks only whether the `FdEntry` exists for the specified key of `__wasi_fd_t` (previously, it also automatically verified that correct rights were passed in)
* validating rights is not performed when dereferencing the `FdEntry` as the `Descriptor`; this essentially postpones the validation allowing for changes in #155 to have the desired effect, while also ensuring that the usage of the abstractions is safe
* adds the test case for behaviour proposed in #155 
* closes #158