### PR TITLE
Fix unused function warnings on Windows.

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,5 @@
 use crate::{Error, Result};
 use std::convert::TryInto;
-use std::ffi::CString;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) fn systemtime_to_timestamp(st: SystemTime) -> Result<u64> {
@@ -9,8 +8,4 @@ pub(crate) fn systemtime_to_timestamp(st: SystemTime) -> Result<u64> {
         .as_nanos()
         .try_into()
         .map_err(Into::into) // u128 doesn't fit into u64
-}
-
-pub(crate) fn str_to_cstring(s: &str) -> Result<CString> {
-    CString::new(s.as_bytes()).map_err(|_| Error::EILSEQ)
 }

--- a/src/hostcalls_impl/fs_helpers.rs
+++ b/src/hostcalls_impl/fs_helpers.rs
@@ -1,9 +1,7 @@
 #![allow(non_camel_case_types)]
-use crate::helpers::str_to_cstring;
 use crate::sys::host_impl;
 use crate::sys::hostcalls_impl::fs_helpers::*;
 use crate::{fdentry::FdEntry, host, Error, Result};
-use std::ffi::CString;
 use std::fs::File;
 use std::path::{Component, Path};
 
@@ -20,10 +18,6 @@ impl PathGet {
 
     pub(crate) fn path(&self) -> &str {
         &self.path
-    }
-
-    pub(crate) fn path_cstring(&self) -> Result<CString> {
-        str_to_cstring(&self.path)
     }
 }
 

--- a/src/sys/unix/bsd/hostcalls_impl.rs
+++ b/src/sys/unix/bsd/hostcalls_impl.rs
@@ -1,7 +1,7 @@
 use super::osfile::OsFile;
-use crate::helpers::str_to_cstring;
 use crate::hostcalls_impl::PathGet;
 use crate::sys::host_impl;
+use crate::sys::unix::str_to_cstring;
 use crate::{host, Error, Result};
 use nix::libc::{self, c_long, c_void};
 use std::convert::TryInto;
@@ -12,7 +12,7 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
     use nix::errno;
     use nix::libc::unlinkat;
 
-    let path_cstr = resolved.path_cstring()?;
+    let path_cstr = str_to_cstring(resolved.path())?;
 
     // nix doesn't expose unlinkat() yet
     match unsafe { unlinkat(resolved.dirfd().as_raw_fd(), path_cstr.as_ptr(), 0) } {
@@ -53,7 +53,7 @@ pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
     use nix::{errno::Errno, fcntl::AtFlags, libc::symlinkat, sys::stat::fstatat};
 
     let old_path_cstr = str_to_cstring(old_path)?;
-    let new_path_cstr = resolved.path_cstring()?;
+    let new_path_cstr = str_to_cstring(resolved.path())?;
 
     log::debug!("path_symlink old_path = {:?}", old_path);
     log::debug!("path_symlink resolved = {:?}", resolved);
@@ -93,8 +93,8 @@ pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
 
 pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> Result<()> {
     use nix::{errno::Errno, fcntl::AtFlags, libc::renameat, sys::stat::fstatat};
-    let old_path_cstr = resolved_old.path_cstring()?;
-    let new_path_cstr = resolved_new.path_cstring()?;
+    let old_path_cstr = str_to_cstring(resolved_old.path())?;
+    let new_path_cstr = str_to_cstring(resolved_new.path())?;
 
     let res = unsafe {
         renameat(

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -14,7 +14,8 @@ mod bsd;
 #[cfg(target_os = "linux")]
 mod linux;
 
-use crate::Result;
+use crate::{Error, Result};
+use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 
@@ -24,6 +25,10 @@ pub(crate) fn dev_null() -> Result<File> {
         .write(true)
         .open("/dev/null")
         .map_err(Into::into)
+}
+
+pub(crate) fn str_to_cstring(s: &str) -> Result<CString> {
+    CString::new(s.as_bytes()).map_err(|_| Error::EILSEQ)
 }
 
 pub fn preopen_dir<P: AsRef<Path>>(path: P) -> Result<File> {


### PR DESCRIPTION
Unfortunately the helpers added in #154 were only used from non-Windows
implementations, which caused compiler warnings on Windows.

This PR moves the helper to be unix-specific and removes the tiny wrapper
around calling `str_to_cstring` on `PathGet.path`.