### PR TITLE
Fix rights in fd_pwrite; cleanup redundant borrows

### DIFF
--- a/src/hostcalls_impl/misc.rs
+++ b/src/hostcalls_impl/misc.rs
@@ -22,7 +22,7 @@ pub(crate) fn args_get(
     let mut argv_buf_offset = 0;
     let mut argv = vec![];
 
-    for arg in wasi_ctx.args.iter() {
+    for arg in &wasi_ctx.args {
         let arg_bytes = arg.as_bytes_with_nul();
         let arg_ptr = argv_buf + argv_buf_offset;
 
@@ -80,7 +80,7 @@ pub(crate) fn environ_get(
     let mut environ_buf_offset = 0;
     let mut environ = vec![];
 
-    for pair in wasi_ctx.env.iter() {
+    for pair in &wasi_ctx.env {
         let env_bytes = pair.as_bytes_with_nul();
         let env_ptr = environ_buf + environ_buf_offset;
 


### PR DESCRIPTION
This commit fixes incorrect rights check in `fd_pwrite`. Until now, we were erroneously checking whether the `Descriptor` has `__WASI_RIGHT_FD_READ` rights instead of `__WASI_RIGHT_FD_WRITE`.

Additionally, this commit removes redundant borrows from `wasi_ctx.get_fd_entry(..)` calls.