### PR TITLE
Sync wasmtime and remove wasm32 deprecated module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ cpu-time = "1.0"
 
 
 [dev-dependencies]
-wasmtime-runtime = { git = "https://github.com/cranestation/wasmtime", rev = "875eea6" }
-wasmtime-environ = { git = "https://github.com/cranestation/wasmtime", rev = "875eea6" }
-wasmtime-jit = { git = "https://github.com/cranestation/wasmtime", rev = "875eea6" }
-wasmtime-wasi = { git = "https://github.com/cranestation/wasmtime", rev = "875eea6" }
-wasmtime-api = { git = "https://github.com/cranestation/wasmtime", rev = "875eea6" }
+wasmtime-runtime = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
+wasmtime-environ = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
+wasmtime-jit = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
+wasmtime-wasi = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
+wasmtime-api = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
 cranelift-codegen = "0.46.1"
 target-lexicon = "0.8.1"
 pretty_env_logger = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,3 @@ pub use sys::preopen_dir;
 
 pub type Error = error::Error;
 pub(crate) type Result<T> = std::result::Result<T, Error>;
-
-// We can remove this once Wasmtime is updated.
-#[deprecated = "wasm32 is deprecated; use wasi or wasi32 instead"]
-pub mod wasm32 {
-    pub use crate::wasi::*;
-    pub use crate::wasi32::*;
-}


### PR DESCRIPTION
Since `wasmtime` now uses `wasi` and `wasi32` modules, we can now
safely remove the `wasm32` module. This commit also updates `wasmtime`
to the latest upstream.