### PR TITLE
Fix path_rename_trailing_slashes test case on Win

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -198,7 +198,6 @@ mod wasm_tests {
                         "symlink_loop" => true,
                         "truncation_rights" => true,
                         "fd_readdir" => true,
-                        "path_rename_trailing_slashes" => true,
                         "poll_oneoff" => true,
                         _ => false,
                     }


### PR DESCRIPTION
This commit adds a utility routine `strip_trailing_slashes_and_concatenate` which is common for `path_rename` and `path_symlink` on Windows, and checks if the resolved `PathGet` indeed contains a trailing slash(es) before striping them off. Secondly, this commit fixes `path_rename_trailing_slashes` test case by adding two additional checks for potentially erroneous conditions, and raising `ENOTDIR` if any happens to be true.