### PR TITLE
Improvements to `WasiCtxBuilder`, and a couple bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,12 @@ cpu-time = "1.0"
 
 
 [dev-dependencies]
-wasmtime-runtime = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
-wasmtime-environ = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
-wasmtime-jit = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
-wasmtime-wasi = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
-wasmtime-api = { git = "https://github.com/cranestation/wasmtime", rev = "b42e550" }
-cranelift-codegen = "0.46.1"
+wasmtime-runtime = { git = "https://github.com/acfoltzer/wasmtime", rev = "d99e2fb" }
+wasmtime-environ = { git = "https://github.com/acfoltzer/wasmtime", rev = "d99e2fb" }
+wasmtime-jit = { git = "https://github.com/acfoltzer/wasmtime", rev = "d99e2fb" }
+wasmtime-wasi = { git = "https://github.com/acfoltzer/wasmtime", rev = "d99e2fb" }
+wasmtime-api = { git = "https://github.com/acfoltzer/wasmtime", rev = "d99e2fb" }
+cranelift-codegen = "0.47.0"
 target-lexicon = "0.8.1"
 pretty_env_logger = "0.3.0"
 tempfile = "3.1.0"

--- a/src/fdentry.rs
+++ b/src/fdentry.rs
@@ -1,3 +1,4 @@
+use crate::sys::dev_null;
 use crate::sys::fdentry_impl::{determine_type_and_access_rights, OsFile};
 use crate::{wasi, Error, Result};
 use std::path::PathBuf;
@@ -127,6 +128,10 @@ impl FdEntry {
                 preopen_path: None,
             },
         )
+    }
+
+    pub(crate) fn null() -> Result<Self> {
+        Self::from(dev_null()?)
     }
 
     /// Convert this `FdEntry` into a host `Descriptor` object provided the specified

--- a/src/sys/unix/bsd/mod.rs
+++ b/src/sys/unix/bsd/mod.rs
@@ -7,9 +7,11 @@ pub(crate) mod fdentry_impl {
 
     pub(crate) unsafe fn isatty(fd: &impl AsRawFd) -> Result<bool> {
         let res = libc::isatty(fd.as_raw_fd());
-        if res == 0 {
+        if res == 1 {
+            // isatty() returns 1 if fd is an open file descriptor referring to a terminal...
             Ok(true)
         } else {
+            // ... otherwise 0 is returned, and errno is set to indicate the error.
             match nix::errno::Errno::last() {
                 nix::errno::Errno::ENOTTY => Ok(false),
                 x => Err(host_impl::errno_from_nix(x)),

--- a/src/sys/unix/linux/mod.rs
+++ b/src/sys/unix/linux/mod.rs
@@ -9,9 +9,11 @@ pub(crate) mod fdentry_impl {
         use nix::errno::Errno;
 
         let res = libc::isatty(fd.as_raw_fd());
-        if res == 0 {
+        if res == 1 {
+            // isatty() returns 1 if fd is an open file descriptor referring to a terminal...
             Ok(true)
         } else {
+            // ... otherwise 0 is returned, and errno is set to indicate the error.
             match Errno::last() {
                 // While POSIX specifies ENOTTY if the passed
                 // fd is *not* a tty, on Linux, some implementations


### PR DESCRIPTION
Note that since this involves changes to the interface that downstream clients have to use, it requires a different commit of `wasmtime` for testing. That `wasmtime` commit is currently on my private fork, so I'm opening this as a draft, as it will need to be amended before merging (**edit:** see https://github.com/CraneStation/wasmtime/pull/490).

Text from the commit messages follows:

This changes the fields on the builder to types that let the various `.arg()`, `.env()`, etc methods
infallible, so we don't have to worry about handling any errors till we actually build. This reduces
line noise when using a builder in a downstream application.

Deferring the processing of the builder fields also has the advantage of eliminating the opening and
closing of `/dev/null` for the default stdio file descriptors unless they're actually used by the
resulting `WasiCtx`.

Now that failures are deferred until `WasiCtxBuilder::build()`, we don't need to have `Result` types
on the other methods any longer.

Additionally, using `IntoIterator` rather than `Iterator` as the trait bound for these methods is
slightly more general, and saves the client some typing.

Unicode errors when inheriting arguments and environment variables no longer cause a panic, but
instead go through `OsString`. We return `ENOTCAPABLE` at the end if there are NULs, or if UTF-8
conversion fails on Windows.

This also changes the bounds on some of the methods from `AsRef<str>` to `AsRef<[u8]>`. This
shouldn't break any existing code, but allows more flexibility when providing arguments. Depending
on the outcome of WebAssembly/WASI#8 we may eventually want to require
these bytes be UTF-8, so we might want to revisit this later (**edit:** we now validate UTF-8 during `build()`).

Finally, this fixes a tiny bug that could arise if we had exactly the maximum number of file
descriptors when populating the preopens, and a bug in the Linux implementation of `isatty()`.